### PR TITLE
Fix json-config dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.0",
-    "@iobroker/json-config": "^1.2.0",
+    "@iobroker/json-config": "^1.1.0",
     "crypto-js": "^4.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- update the @iobroker/json-config dependency to use the published ^1.1.0 range

## Testing
- npm install *(fails: registry access returns 403 Forbidden in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e62ddf748325856622a81ecbc7b5