### PR TITLE
Fix json-config dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.0",
-    "@iobroker/json-config": "^1.1.0",
+    "@iobroker/json-config": "^1.0.0",
     "crypto-js": "^4.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- adjust the @iobroker/json-config dependency to the published ^1.0.0 range to allow installation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7e88e196c832587721f69fcf20124