### PR TITLE
Fix datapoint selector in polling configuration

### DIFF
--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -14,5 +14,15 @@
   "enabled": "Enabled",
   "dataPoint": "Data point",
   "interval": "Interval",
-  "customPolling": "Enable custom polling per data point"
+  "customPolling": "Enable custom polling per data point",
+  "power": "Leistung",
+  "mode": "Modus",
+  "targetTemperature": "Solltemperatur",
+  "indoorTemperature": "Innentemperatur",
+  "outdoorTemperature": "Außentemperatur",
+  "fanSpeed": "Lüftergeschwindigkeit",
+  "swingMode": "Swing-Modus",
+  "ecoMode": "Eco-Modus",
+  "turboMode": "Turbo-Modus",
+  "sleepMode": "Sleep-Modus"
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -14,5 +14,15 @@
   "enabled": "Enabled",
   "dataPoint": "Data point",
   "interval": "Interval",
-  "customPolling": "Enable custom polling per data point"
+  "customPolling": "Enable custom polling per data point",
+  "power": "Power",
+  "mode": "Mode",
+  "targetTemperature": "Target temperature",
+  "indoorTemperature": "Indoor temperature",
+  "outdoorTemperature": "Outdoor temperature",
+  "fanSpeed": "Fan speed",
+  "swingMode": "Swing mode",
+  "ecoMode": "Eco mode",
+  "turboMode": "Turbo mode",
+  "sleepMode": "Sleep mode"
 }

--- a/admin/i18n/es/translations.json
+++ b/admin/i18n/es/translations.json
@@ -14,5 +14,15 @@
   "enabled": "Enabled",
   "dataPoint": "Data point",
   "interval": "Interval",
-  "customPolling": "Enable custom polling per data point"
+  "customPolling": "Enable custom polling per data point",
+  "power": "Power",
+  "mode": "Mode",
+  "targetTemperature": "Target temperature",
+  "indoorTemperature": "Indoor temperature",
+  "outdoorTemperature": "Outdoor temperature",
+  "fanSpeed": "Fan speed",
+  "swingMode": "Swing mode",
+  "ecoMode": "Eco mode",
+  "turboMode": "Turbo mode",
+  "sleepMode": "Sleep mode"
 }

--- a/admin/i18n/fr/translations.json
+++ b/admin/i18n/fr/translations.json
@@ -14,5 +14,15 @@
   "enabled": "Enabled",
   "dataPoint": "Data point",
   "interval": "Interval",
-  "customPolling": "Enable custom polling per data point"
+  "customPolling": "Enable custom polling per data point",
+  "power": "Power",
+  "mode": "Mode",
+  "targetTemperature": "Target temperature",
+  "indoorTemperature": "Indoor temperature",
+  "outdoorTemperature": "Outdoor temperature",
+  "fanSpeed": "Fan speed",
+  "swingMode": "Swing mode",
+  "ecoMode": "Eco mode",
+  "turboMode": "Turbo mode",
+  "sleepMode": "Sleep mode"
 }

--- a/admin/i18n/it/translations.json
+++ b/admin/i18n/it/translations.json
@@ -14,5 +14,15 @@
   "enabled": "Enabled",
   "dataPoint": "Data point",
   "interval": "Interval",
-  "customPolling": "Enable custom polling per data point"
+  "customPolling": "Enable custom polling per data point",
+  "power": "Power",
+  "mode": "Mode",
+  "targetTemperature": "Target temperature",
+  "indoorTemperature": "Indoor temperature",
+  "outdoorTemperature": "Outdoor temperature",
+  "fanSpeed": "Fan speed",
+  "swingMode": "Swing mode",
+  "ecoMode": "Eco mode",
+  "turboMode": "Turbo mode",
+  "sleepMode": "Sleep mode"
 }

--- a/admin/i18n/nl/translations.json
+++ b/admin/i18n/nl/translations.json
@@ -14,5 +14,15 @@
   "enabled": "Enabled",
   "dataPoint": "Data point",
   "interval": "Interval",
-  "customPolling": "Enable custom polling per data point"
+  "customPolling": "Enable custom polling per data point",
+  "power": "Power",
+  "mode": "Mode",
+  "targetTemperature": "Target temperature",
+  "indoorTemperature": "Indoor temperature",
+  "outdoorTemperature": "Outdoor temperature",
+  "fanSpeed": "Fan speed",
+  "swingMode": "Swing mode",
+  "ecoMode": "Eco mode",
+  "turboMode": "Turbo mode",
+  "sleepMode": "Sleep mode"
 }

--- a/admin/i18n/pl/translations.json
+++ b/admin/i18n/pl/translations.json
@@ -14,5 +14,15 @@
   "enabled": "Enabled",
   "dataPoint": "Data point",
   "interval": "Interval",
-  "customPolling": "Enable custom polling per data point"
+  "customPolling": "Enable custom polling per data point",
+  "power": "Power",
+  "mode": "Mode",
+  "targetTemperature": "Target temperature",
+  "indoorTemperature": "Indoor temperature",
+  "outdoorTemperature": "Outdoor temperature",
+  "fanSpeed": "Fan speed",
+  "swingMode": "Swing mode",
+  "ecoMode": "Eco mode",
+  "turboMode": "Turbo mode",
+  "sleepMode": "Sleep mode"
 }

--- a/admin/i18n/pt/translations.json
+++ b/admin/i18n/pt/translations.json
@@ -14,5 +14,15 @@
   "enabled": "Enabled",
   "dataPoint": "Data point",
   "interval": "Interval",
-  "customPolling": "Enable custom polling per data point"
+  "customPolling": "Enable custom polling per data point",
+  "power": "Power",
+  "mode": "Mode",
+  "targetTemperature": "Target temperature",
+  "indoorTemperature": "Indoor temperature",
+  "outdoorTemperature": "Outdoor temperature",
+  "fanSpeed": "Fan speed",
+  "swingMode": "Swing mode",
+  "ecoMode": "Eco mode",
+  "turboMode": "Turbo mode",
+  "sleepMode": "Sleep mode"
 }

--- a/admin/i18n/ru/translations.json
+++ b/admin/i18n/ru/translations.json
@@ -14,5 +14,15 @@
   "enabled": "Enabled",
   "dataPoint": "Data point",
   "interval": "Interval",
-  "customPolling": "Enable custom polling per data point"
+  "customPolling": "Enable custom polling per data point",
+  "power": "Power",
+  "mode": "Mode",
+  "targetTemperature": "Target temperature",
+  "indoorTemperature": "Indoor temperature",
+  "outdoorTemperature": "Outdoor temperature",
+  "fanSpeed": "Fan speed",
+  "swingMode": "Swing mode",
+  "ecoMode": "Eco mode",
+  "turboMode": "Turbo mode",
+  "sleepMode": "Sleep mode"
 }

--- a/admin/i18n/uk/translations.json
+++ b/admin/i18n/uk/translations.json
@@ -14,5 +14,15 @@
   "enabled": "Enabled",
   "dataPoint": "Data point",
   "interval": "Interval",
-  "customPolling": "Enable custom polling per data point"
+  "customPolling": "Enable custom polling per data point",
+  "power": "Power",
+  "mode": "Mode",
+  "targetTemperature": "Target temperature",
+  "indoorTemperature": "Indoor temperature",
+  "outdoorTemperature": "Outdoor temperature",
+  "fanSpeed": "Fan speed",
+  "swingMode": "Swing mode",
+  "ecoMode": "Eco mode",
+  "turboMode": "Turbo mode",
+  "sleepMode": "Sleep mode"
 }

--- a/admin/i18n/zh-cn/translations.json
+++ b/admin/i18n/zh-cn/translations.json
@@ -14,5 +14,15 @@
   "enabled": "Enabled",
   "dataPoint": "Data point",
   "interval": "Interval",
-  "customPolling": "Enable custom polling per data point"
+  "customPolling": "Enable custom polling per data point",
+  "power": "Power",
+  "mode": "Mode",
+  "targetTemperature": "Target temperature",
+  "indoorTemperature": "Indoor temperature",
+  "outdoorTemperature": "Outdoor temperature",
+  "fanSpeed": "Fan speed",
+  "swingMode": "Swing mode",
+  "ecoMode": "Eco mode",
+  "turboMode": "Turbo mode",
+  "sleepMode": "Sleep mode"
 }

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -78,10 +78,21 @@
               "default": true
             },
             {
-              "type": "text",
+              "type": "select",
               "name": "id",
               "label": "dataPoint",
-              "readonly": true
+              "options": [
+                { "value": "power", "label": "power" },
+                { "value": "mode", "label": "mode" },
+                { "value": "targetTemperature", "label": "targetTemperature" },
+                { "value": "indoorTemperature", "label": "indoorTemperature" },
+                { "value": "outdoorTemperature", "label": "outdoorTemperature" },
+                { "value": "fanSpeed", "label": "fanSpeed" },
+                { "value": "swingMode", "label": "swingMode" },
+                { "value": "ecoMode", "label": "ecoMode" },
+                { "value": "turboMode", "label": "turboMode" },
+                { "value": "sleepMode", "label": "sleepMode" }
+              ]
             },
             {
               "type": "number",
@@ -98,8 +109,7 @@
             "label": "customPolling",
             "attr": "customPolling",
             "default": false
-          },
-          "tableSource": "datapoints"
+          }
         }
       ]
     }
@@ -120,6 +130,16 @@
     "enabled": "enabled",
     "dataPoint": "dataPoint",
     "interval": "interval",
-    "customPolling": "customPolling"
+    "customPolling": "customPolling",
+    "power": "power",
+    "mode": "mode",
+    "targetTemperature": "targetTemperature",
+    "indoorTemperature": "indoorTemperature",
+    "outdoorTemperature": "outdoorTemperature",
+    "fanSpeed": "fanSpeed",
+    "swingMode": "swingMode",
+    "ecoMode": "ecoMode",
+    "turboMode": "turboMode",
+    "sleepMode": "sleepMode"
   }
 }


### PR DESCRIPTION
## Summary
- replace the polling table datapoint column with a select box so users can choose supported IDs directly
- add translation entries for each datapoint label in every bundled language

## Testing
- npm install *(fails: npm returns 403 Forbidden for @iobroker/adapter-core)*

------
https://chatgpt.com/codex/tasks/task_e_68d7f6f5ba108325b94b8b7485bc9bea