### PR TITLE
Fix polling table bindings in admin config

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -68,18 +68,21 @@
         {
           "type": "table",
           "name": "requests",
+          "attr": "requests",
           "label": "pollingRequests",
           "help": "pollingRequests_help",
           "items": [
             {
               "type": "checkbox",
               "name": "enabled",
+              "attr": "enabled",
               "label": "enabled",
               "default": true
             },
             {
               "type": "select",
               "name": "id",
+              "attr": "id",
               "label": "dataPoint",
               "options": [
                 { "value": "power", "label": "power" },
@@ -97,6 +100,7 @@
             {
               "type": "number",
               "name": "interval",
+              "attr": "interval",
               "label": "interval",
               "default": 60,
               "min": 5,


### PR DESCRIPTION
## Summary
- bind the polling table to the correct native attributes
- ensure each table column stores its value under the expected key

## Testing
- npm test *(fails: repository does not include an ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d7fbe6331c83258a584e48bbed2f8c