### PR TITLE
Fix polling table config binding for JSON admin UI

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -68,7 +68,7 @@
         {
           "type": "table",
           "name": "requests",
-          "attr": "requests",
+          "attr": "polling.requests",
           "label": "pollingRequests",
           "help": "pollingRequests_help",
           "items": [
@@ -111,7 +111,7 @@
           "custom": {
             "type": "checkbox",
             "label": "customPolling",
-            "attr": "customPolling",
+            "attr": "polling.customPolling",
             "default": false
           }
         }

--- a/io-package.json
+++ b/io-package.json
@@ -64,6 +64,7 @@
     "pollingInterval": 60,
     "reconnectInterval": 10,
     "polling": {
+      "customPolling": false,
       "requests": []
     }
   },


### PR DESCRIPTION
## Summary
- bind the polling requests table to `native.polling.requests` so editing entries no longer overwrites the host field
- provide a default value for the custom polling toggle in the adapter's native configuration

## Testing
- not run (dependency installation blocked by npm registry access restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68d800cec09083258efbf58fa0961374