### PR TITLE
Normalize and persist adapter config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.2 (2025-09-27)
+
+* normalize and persist adapter configuration to keep the host field stable in the admin UI
+
 ## 0.0.1 (2025-09-27)
 
 * initial release


### PR DESCRIPTION
## Summary
- normalize the adapter configuration at startup to clean invalid host and polling entries
- persist the sanitized configuration back to the instance so the admin UI keeps the host field stable
- document the fix in the changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d80711537c83258bd2696af37c2543