### PR TITLE
Use tabs to separate connection and polling settings

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -1,5 +1,5 @@
 {
-  "type": "panel",
+  "type": "tabs",
   "items": [
     {
       "type": "panel",


### PR DESCRIPTION
## Summary
- change the admin configuration layout to use tabs instead of a single panel
- keep the connection settings on the first tab and move polling requests to a second tab

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d81ef61454832591b054a37aeb1372