### PR TITLE
Fix admin config schema collisions

### DIFF
--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -24,5 +24,6 @@
   "swingMode": "Swing-Modus",
   "ecoMode": "Eco-Modus",
   "turboMode": "Turbo-Modus",
-  "sleepMode": "Sleep-Modus"
+  "sleepMode": "Sleep-Modus",
+  "customPolling_help": "Allow configuring individual polling intervals per data point."
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -24,5 +24,6 @@
   "swingMode": "Swing mode",
   "ecoMode": "Eco mode",
   "turboMode": "Turbo mode",
-  "sleepMode": "Sleep mode"
+  "sleepMode": "Sleep mode",
+  "customPolling_help": "Allow configuring individual polling intervals per data point."
 }

--- a/admin/i18n/es/translations.json
+++ b/admin/i18n/es/translations.json
@@ -24,5 +24,6 @@
   "swingMode": "Swing mode",
   "ecoMode": "Eco mode",
   "turboMode": "Turbo mode",
-  "sleepMode": "Sleep mode"
+  "sleepMode": "Sleep mode",
+  "customPolling_help": "Allow configuring individual polling intervals per data point."
 }

--- a/admin/i18n/fr/translations.json
+++ b/admin/i18n/fr/translations.json
@@ -24,5 +24,6 @@
   "swingMode": "Swing mode",
   "ecoMode": "Eco mode",
   "turboMode": "Turbo mode",
-  "sleepMode": "Sleep mode"
+  "sleepMode": "Sleep mode",
+  "customPolling_help": "Allow configuring individual polling intervals per data point."
 }

--- a/admin/i18n/it/translations.json
+++ b/admin/i18n/it/translations.json
@@ -24,5 +24,6 @@
   "swingMode": "Swing mode",
   "ecoMode": "Eco mode",
   "turboMode": "Turbo mode",
-  "sleepMode": "Sleep mode"
+  "sleepMode": "Sleep mode",
+  "customPolling_help": "Allow configuring individual polling intervals per data point."
 }

--- a/admin/i18n/nl/translations.json
+++ b/admin/i18n/nl/translations.json
@@ -24,5 +24,6 @@
   "swingMode": "Swing mode",
   "ecoMode": "Eco mode",
   "turboMode": "Turbo mode",
-  "sleepMode": "Sleep mode"
+  "sleepMode": "Sleep mode",
+  "customPolling_help": "Allow configuring individual polling intervals per data point."
 }

--- a/admin/i18n/pl/translations.json
+++ b/admin/i18n/pl/translations.json
@@ -24,5 +24,6 @@
   "swingMode": "Swing mode",
   "ecoMode": "Eco mode",
   "turboMode": "Turbo mode",
-  "sleepMode": "Sleep mode"
+  "sleepMode": "Sleep mode",
+  "customPolling_help": "Allow configuring individual polling intervals per data point."
 }

--- a/admin/i18n/pt/translations.json
+++ b/admin/i18n/pt/translations.json
@@ -24,5 +24,6 @@
   "swingMode": "Swing mode",
   "ecoMode": "Eco mode",
   "turboMode": "Turbo mode",
-  "sleepMode": "Sleep mode"
+  "sleepMode": "Sleep mode",
+  "customPolling_help": "Allow configuring individual polling intervals per data point."
 }

--- a/admin/i18n/ru/translations.json
+++ b/admin/i18n/ru/translations.json
@@ -24,5 +24,6 @@
   "swingMode": "Swing mode",
   "ecoMode": "Eco mode",
   "turboMode": "Turbo mode",
-  "sleepMode": "Sleep mode"
+  "sleepMode": "Sleep mode",
+  "customPolling_help": "Allow configuring individual polling intervals per data point."
 }

--- a/admin/i18n/uk/translations.json
+++ b/admin/i18n/uk/translations.json
@@ -24,5 +24,6 @@
   "swingMode": "Swing mode",
   "ecoMode": "Eco mode",
   "turboMode": "Turbo mode",
-  "sleepMode": "Sleep mode"
+  "sleepMode": "Sleep mode",
+  "customPolling_help": "Allow configuring individual polling intervals per data point."
 }

--- a/admin/i18n/zh-cn/translations.json
+++ b/admin/i18n/zh-cn/translations.json
@@ -24,5 +24,6 @@
   "swingMode": "Swing mode",
   "ecoMode": "Eco mode",
   "turboMode": "Turbo mode",
-  "sleepMode": "Sleep mode"
+  "sleepMode": "Sleep mode",
+  "customPolling_help": "Allow configuring individual polling intervals per data point."
 }

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -1,14 +1,12 @@
 {
   "type": "tabs",
-  "items": [
-    {
+  "items": {
+    "connection": {
       "type": "panel",
-      "name": "connection",
       "label": "general",
-      "items": [
-        {
+      "items": {
+        "host": {
           "type": "text",
-          "name": "host",
           "label": "host",
           "attr": "host",
           "default": "192.168.1.100",
@@ -17,9 +15,8 @@
           "sm": 6,
           "md": 4
         },
-        {
+        "port": {
           "type": "number",
-          "name": "port",
           "label": "port",
           "attr": "port",
           "default": 23,
@@ -30,9 +27,8 @@
           "sm": 6,
           "md": 4
         },
-        {
+        "pollingInterval": {
           "type": "number",
-          "name": "pollingInterval",
           "label": "pollingInterval",
           "attr": "pollingInterval",
           "default": 60,
@@ -44,9 +40,8 @@
           "sm": 6,
           "md": 4
         },
-        {
+        "reconnectInterval": {
           "type": "number",
-          "name": "reconnectInterval",
           "label": "reconnectInterval",
           "attr": "reconnectInterval",
           "default": 10,
@@ -58,30 +53,34 @@
           "sm": 6,
           "md": 4
         }
-      ]
+      }
     },
-    {
+    "polling": {
       "type": "panel",
-      "name": "polling",
       "label": "polling",
-      "items": [
-        {
+      "items": {
+        "customPolling": {
+          "type": "checkbox",
+          "label": "customPolling",
+          "attr": "customPolling",
+          "default": false,
+          "help": "customPolling_help",
+          "xs": 12
+        },
+        "requests": {
           "type": "table",
-          "name": "requests",
           "attr": "pollingRequests",
           "label": "pollingRequests",
           "help": "pollingRequests_help",
           "items": [
             {
               "type": "checkbox",
-              "name": "enabled",
               "attr": "enabled",
               "label": "enabled",
               "default": true
             },
             {
               "type": "select",
-              "name": "id",
               "attr": "id",
               "label": "dataPoint",
               "options": [
@@ -99,7 +98,6 @@
             },
             {
               "type": "number",
-              "name": "interval",
               "attr": "interval",
               "label": "interval",
               "default": 60,
@@ -107,17 +105,11 @@
               "max": 3600,
               "unit": "s"
             }
-          ],
-          "custom": {
-            "type": "checkbox",
-            "label": "customPolling",
-            "attr": "customPolling",
-            "default": false
-          }
+          ]
         }
-      ]
+      }
     }
-  ],
+  },
   "translations": {
     "general": "general",
     "host": "host",
@@ -135,6 +127,7 @@
     "dataPoint": "dataPoint",
     "interval": "interval",
     "customPolling": "customPolling",
+    "customPolling_help": "customPolling_help",
     "power": "power",
     "mode": "mode",
     "targetTemperature": "targetTemperature",

--- a/main.js
+++ b/main.js
@@ -221,6 +221,36 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
   _normalizeConfig() {
     let changed = false;
 
+    const moveLegacyValue = (legacyKey, targetKey, predicate = () => true) => {
+      if (!Object.prototype.hasOwnProperty.call(this.config, legacyKey)) {
+        return;
+      }
+
+      const legacyValue = this.config[legacyKey];
+      if (predicate(legacyValue) && this.config[targetKey] === undefined) {
+        this.config[targetKey] = legacyValue;
+      }
+
+      delete this.config[legacyKey];
+      changed = true;
+    };
+
+    if (Object.prototype.hasOwnProperty.call(this.config, '0')) {
+      const legacyZero = this.config['0'];
+      if (typeof legacyZero === 'string' && this.config.host === undefined) {
+        this.config.host = legacyZero;
+      } else if (Array.isArray(legacyZero) && !Array.isArray(this.config.pollingRequests)) {
+        this.config.pollingRequests = legacyZero;
+      }
+      delete this.config['0'];
+      changed = true;
+    }
+
+    moveLegacyValue('1', 'port');
+    moveLegacyValue('2', 'pollingInterval');
+    moveLegacyValue('3', 'reconnectInterval');
+    moveLegacyValue('4', 'customPolling', (value) => typeof value === 'boolean');
+
     const originalHost = this.config.host;
     let normalizedHost = originalHost;
 


### PR DESCRIPTION
## Summary
- restructure the admin jsonConfig to use keyed panels and add a separate custom polling toggle help text so host/polling values persist
- add config normalization that migrates legacy numeric keys back to host, port, polling intervals, and polling requests

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8202b5c98832584de72283316e0ce