### PR TITLE
Fix missing info.connection object creation

### DIFF
--- a/main.js
+++ b/main.js
@@ -116,6 +116,19 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
       native: {},
     });
 
+    await this.setObjectNotExistsAsync('info.connection', {
+      type: 'state',
+      common: {
+        name: 'Connection status',
+        type: 'boolean',
+        role: 'indicator.connected',
+        read: true,
+        write: false,
+        def: false,
+      },
+      native: {},
+    });
+
     await this.setObjectNotExistsAsync('control', {
       type: 'channel',
       common: {


### PR DESCRIPTION
## Summary
- add creation of the `info.connection` state so the connection status can be updated without warnings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d82a1cb85083258a014431abaa535f