### PR TITLE
Improve debug logging for bridge communication

### DIFF
--- a/lib/midea-serial-bridge.js
+++ b/lib/midea-serial-bridge.js
@@ -4,6 +4,21 @@ const net = require('net');
 const EventEmitter = require('events');
 const { encodeFrame, decodeFrame, REQUESTS } = require('./protocol');
 
+function formatBuffer(buffer, maxLength = 256) {
+  if (!buffer || buffer.length === 0) {
+    return '<empty>';
+  }
+
+  const length = Math.min(buffer.length, maxLength);
+  const hex = buffer.slice(0, length).toString('hex');
+  const bytes = hex.match(/.{1,2}/g) || [];
+  const spaced = bytes.join(' ');
+  if (length < buffer.length) {
+    return `${spaced} …(${buffer.length} bytes total)`;
+  }
+  return spaced;
+}
+
 class MideaSerialBridge extends EventEmitter {
   constructor(options) {
     super();
@@ -80,6 +95,10 @@ class MideaSerialBridge extends EventEmitter {
   }
 
   _handleData(chunk) {
+    this.log.debug(
+      `Received data chunk (${chunk.length} bytes) from bridge: ${formatBuffer(chunk)}`
+    );
+
     this.buffer = Buffer.concat([this.buffer, chunk]);
 
     let frame;
@@ -103,35 +122,66 @@ class MideaSerialBridge extends EventEmitter {
 
     const key = frame.sequence != null ? frame.sequence : null;
 
+    const commandHex = `0x${frame.command.toString(16).padStart(2, '0')}`;
+    this.log.debug(
+      `Decoded frame sequence ${frame.sequence} (${frame.type}, command ${commandHex}) with payload (${frame.payloadLength} bytes): ${formatBuffer(frame.payload)}`
+    );
+
     if (key && this.pending.has(key)) {
-      const { resolve, reject, timeout } = this.pending.get(key);
+      const { resolve, reject, timeout, metadata } = this.pending.get(key);
       clearTimeout(timeout);
       this.pending.delete(key);
 
       if (frame.type === 'error') {
+        if (metadata) {
+          this.log.debug(
+            `Bridge responded with error for ${metadata.operation || 'request'} ${
+              metadata.datapointId || 'unknown'
+            } (sequence ${key})`
+          );
+        }
         reject(new Error(frame.message || 'Bridge returned an error'));
         return;
       }
 
+      if (metadata) {
+        this.log.debug(
+          `Received response for ${metadata.operation || 'request'} ${
+            metadata.datapointId || 'unknown'
+          } (sequence ${key})`
+        );
+      }
       resolve(frame.payload);
       return;
     }
 
+    this.log.debug(
+      `Received unsolicited frame (sequence ${frame.sequence}). Raw: ${formatBuffer(rawFrame)}`
+    );
     this.emit('frame', frame, rawFrame);
   }
 
-  _sendRequest(buffer, sequence) {
+  _sendRequest(buffer, sequence, metadata = {}) {
     if (!this.connected || !this.socket) {
       return Promise.reject(new Error('Not connected to serial bridge'));
     }
 
     return new Promise((resolve, reject) => {
+      const context = metadata.datapointId
+        ? `${metadata.operation || 'request'} ${metadata.datapointId}`
+        : `sequence ${sequence}`;
+      this.log.debug(
+        `Sending ${context} to bridge (${buffer.length} bytes): ${formatBuffer(buffer)}`
+      );
+
+      const timeoutMs = typeof metadata.timeout === 'number' ? metadata.timeout : 5000;
       const timeout = setTimeout(() => {
         this.pending.delete(sequence);
+        this.log.debug(`Timeout waiting for response to ${context} (sequence ${sequence})`);
         reject(new Error('Request timed out'));
-      }, 5000);
+      }, timeoutMs);
 
-      this.pending.set(sequence, { resolve, reject, timeout });
+      this.pending.set(sequence, { resolve, reject, timeout, metadata });
 
       this.socket.write(buffer);
     });
@@ -144,7 +194,11 @@ class MideaSerialBridge extends EventEmitter {
     }
 
     const { buffer, sequence } = encodeFrame(definition.query, params);
-    const payload = await this._sendRequest(buffer, sequence);
+    const payload = await this._sendRequest(buffer, sequence, {
+      datapointId,
+      operation: 'query',
+      command: definition.query.command,
+    });
     if (definition.parse) {
       return definition.parse(payload, params);
     }
@@ -159,7 +213,11 @@ class MideaSerialBridge extends EventEmitter {
     }
 
     const { buffer, sequence } = encodeFrame(definition.set, { value, ...params });
-    const payload = await this._sendRequest(buffer, sequence);
+    const payload = await this._sendRequest(buffer, sequence, {
+      datapointId,
+      operation: 'set',
+      command: definition.set.command,
+    });
     if (definition.parse) {
       return definition.parse(payload, params);
     }


### PR DESCRIPTION
## Summary
- add helper to format bridge frames for readable debug output
- log outgoing requests, incoming frames, and response handling with context
- surface request metadata and timeouts to aid troubleshooting

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8428696988325b307f6e5319add47