### PR TITLE
Handle serial bridge disconnects and queue requests

### DIFF
--- a/lib/midea-serial-bridge.js
+++ b/lib/midea-serial-bridge.js
@@ -32,6 +32,7 @@ class MideaSerialBridge extends EventEmitter {
     this.buffer = Buffer.alloc(0);
     this.pending = new Map();
     this.reconnectTimer = null;
+    this._sendChain = Promise.resolve();
   }
 
   connect() {
@@ -52,6 +53,7 @@ class MideaSerialBridge extends EventEmitter {
 
     this.socket.on('error', (error) => {
       this.log.error(`Serial bridge error: ${error.message}`);
+      this._rejectAllPending(new Error(`Serial bridge error: ${error.message}`));
       this._scheduleReconnect();
       this.emit('error', error);
     });
@@ -61,6 +63,8 @@ class MideaSerialBridge extends EventEmitter {
       this.connected = false;
       this.socket = null;
       this.emit('disconnected');
+      this._rejectAllPending(new Error('Serial bridge connection closed'));
+      this._sendChain = Promise.resolve();
       this._scheduleReconnect();
     });
 
@@ -81,6 +85,31 @@ class MideaSerialBridge extends EventEmitter {
     }
 
     this.connected = false;
+    this._rejectAllPending(new Error('Disconnected from serial bridge'));
+    this._sendChain = Promise.resolve();
+  }
+
+  _rejectAllPending(error) {
+    if (!error) {
+      error = new Error('Request aborted');
+    }
+
+    for (const [sequence, pending] of this.pending.entries()) {
+      const { reject, timeout, metadata } = pending;
+      clearTimeout(timeout);
+      if (metadata) {
+        const context = metadata.datapointId
+          ? `${metadata.operation || 'request'} ${metadata.datapointId}`
+          : `sequence ${sequence}`;
+        this.log.debug(`Rejecting pending ${context} due to connection issue: ${error.message}`);
+      }
+      try {
+        reject(error);
+      } catch (rejectError) {
+        this.log.debug(`Failed to reject pending request ${sequence}: ${rejectError.message}`);
+      }
+    }
+    this.pending.clear();
   }
 
   _scheduleReconnect() {
@@ -162,29 +191,44 @@ class MideaSerialBridge extends EventEmitter {
   }
 
   _sendRequest(buffer, sequence, metadata = {}) {
-    if (!this.connected || !this.socket) {
-      return Promise.reject(new Error('Not connected to serial bridge'));
-    }
+    const execute = () => {
+      if (!this.connected || !this.socket) {
+        return Promise.reject(new Error('Not connected to serial bridge'));
+      }
 
-    return new Promise((resolve, reject) => {
-      const context = metadata.datapointId
-        ? `${metadata.operation || 'request'} ${metadata.datapointId}`
-        : `sequence ${sequence}`;
-      this.log.debug(
-        `Sending ${context} to bridge (${buffer.length} bytes): ${formatBuffer(buffer)}`
-      );
+      return new Promise((resolve, reject) => {
+        const context = metadata.datapointId
+          ? `${metadata.operation || 'request'} ${metadata.datapointId}`
+          : `sequence ${sequence}`;
+        this.log.debug(
+          `Sending ${context} to bridge (${buffer.length} bytes): ${formatBuffer(buffer)}`
+        );
 
-      const timeoutMs = typeof metadata.timeout === 'number' ? metadata.timeout : 5000;
-      const timeout = setTimeout(() => {
-        this.pending.delete(sequence);
-        this.log.debug(`Timeout waiting for response to ${context} (sequence ${sequence})`);
-        reject(new Error('Request timed out'));
-      }, timeoutMs);
+        const timeoutMs = typeof metadata.timeout === 'number' ? metadata.timeout : 5000;
+        const timeout = setTimeout(() => {
+          this.pending.delete(sequence);
+          this.log.debug(`Timeout waiting for response to ${context} (sequence ${sequence})`);
+          reject(new Error('Request timed out'));
+        }, timeoutMs);
 
-      this.pending.set(sequence, { resolve, reject, timeout, metadata });
+        this.pending.set(sequence, { resolve, reject, timeout, metadata });
 
-      this.socket.write(buffer);
-    });
+        this.socket.write(buffer, (error) => {
+          if (error) {
+            clearTimeout(timeout);
+            this.pending.delete(sequence);
+            this.log.debug(
+              `Failed to send ${context} to bridge (sequence ${sequence}): ${error.message}`
+            );
+            reject(error);
+          }
+        });
+      });
+    };
+
+    const queued = this._sendChain.then(execute);
+    this._sendChain = queued.catch(() => {});
+    return queued;
   }
 
   async query(datapointId, params = {}) {


### PR DESCRIPTION
## Summary
- queue serial bridge writes to avoid sending multiple concurrent frames
- reject all pending queries when the TCP link drops or write fails to prevent long timeouts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8448c383883259d985a1680970c38