### PR TITLE
Handle status frames from bridge

### DIFF
--- a/lib/midea-serial-bridge.js
+++ b/lib/midea-serial-bridge.js
@@ -145,7 +145,23 @@ class MideaSerialBridge extends EventEmitter {
 
   _handleFrame(frame, rawFrame) {
     if (frame.error) {
+      if (frame.type === 'status') {
+        this.log.debug(`Ignoring status frame with invalid checksum`);
+        return;
+      }
       this.log.warn(`Received invalid frame: ${frame.error}`);
+      return;
+    }
+
+    if (frame.type === 'status') {
+      this.log.debug(
+        `Received status frame (command 0x${frame.command
+          .toString(16)
+          .padStart(2, '0')}) with payload (${frame.payloadLength} bytes): ${formatBuffer(
+          frame.payload
+        )}`
+      );
+      this.emit('status', frame, rawFrame);
       return;
     }
 

--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -58,15 +58,57 @@ function encodeFrame(definition, params = {}) {
 }
 
 function decodeFrame(buffer) {
-  if (buffer.length < 6) {
+  if (!buffer || buffer.length === 0) {
     return null;
   }
 
-  if (buffer[0] !== 0xaa || buffer[1] !== 0x55) {
+  if (buffer[0] !== 0xaa) {
     return {
       frameLength: 1,
       error: 'Invalid frame header',
     };
+  }
+
+  if (buffer.length < 2) {
+    return null;
+  }
+
+  if (buffer[1] !== 0x55) {
+    const declaredLength = buffer[1];
+    const frameLength = declaredLength + 1;
+
+    if (buffer.length < frameLength) {
+      return null;
+    }
+
+    const frame = buffer.slice(0, frameLength);
+    const checksum = frame[frame.length - 1];
+    let sum = 0;
+    for (let i = 1; i < frame.length - 1; i++) {
+      sum = (sum + frame[i]) & 0xff;
+    }
+    const expectedChecksum = (0x100 - sum) & 0xff;
+
+    if (checksum !== expectedChecksum) {
+      return {
+        frameLength,
+        error: 'Checksum mismatch',
+        type: 'status',
+      };
+    }
+
+    return {
+      frameLength,
+      command: frame[2],
+      payload: frame.slice(2, frame.length - 1),
+      payloadLength: frame.length - 3,
+      sequence: null,
+      type: 'status',
+    };
+  }
+
+  if (buffer.length < 6) {
+    return null;
   }
 
   const sequence = buffer[2];

--- a/main.js
+++ b/main.js
@@ -77,6 +77,14 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
         this.log.error(`Serial bridge error: ${error.message}`);
       });
 
+      this.bridge.on('status', (frame) => {
+        this.log.debug(
+          `Received unsolicited status frame (command 0x${frame.command
+            .toString(16)
+            .padStart(2, '0')})`
+        );
+      });
+
       this.bridge.connect();
     } catch (error) {
       const message = this._formatError(error);


### PR DESCRIPTION
## Summary
- extend the protocol decoder to recognise length-prefixed status frames from the bridge and verify their checksum
- treat the decoded status frames as dedicated events instead of reporting them as invalid data
- log receipt of unsolicited status frames in the adapter to aid troubleshooting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d847559f748325944d35edb5b14810