### PR TITLE
Refactor status polling to use bridge status requests

### DIFF
--- a/lib/midea-serial-bridge.js
+++ b/lib/midea-serial-bridge.js
@@ -2,7 +2,7 @@
 
 const net = require('net');
 const EventEmitter = require('events');
-const { encodeFrame, decodeFrame, REQUESTS } = require('./protocol');
+const { encodeFrame, decodeFrame, REQUESTS, STATUS_REQUEST } = require('./protocol');
 const { parseStatusFrame } = require('./status-parser');
 
 function formatBuffer(buffer, maxLength = 256) {
@@ -37,6 +37,8 @@ class MideaSerialBridge extends EventEmitter {
     this.statusVersion = 0;
     this.statusValues = new Map();
     this.statusWaiters = new Map();
+    this.statusUpdateWaiters = new Set();
+    this._lastStatusRequestAt = 0;
   }
 
   connect() {
@@ -235,6 +237,8 @@ class MideaSerialBridge extends EventEmitter {
       this.statusValues.set(datapointId, { value, version });
       this._notifyStatusWaiters(datapointId, value, version);
     }
+
+    this._notifyStatusUpdateWaiters(version);
   }
 
   _addStatusWaiter(datapointId, waiter) {
@@ -272,6 +276,22 @@ class MideaSerialBridge extends EventEmitter {
     }
   }
 
+  _notifyStatusUpdateWaiters(version) {
+    if (!this.statusUpdateWaiters || this.statusUpdateWaiters.size === 0) {
+      return;
+    }
+
+    for (const waiter of Array.from(this.statusUpdateWaiters)) {
+      if (version > waiter.minVersion) {
+        try {
+          waiter.resolve(version);
+        } catch (error) {
+          this.log.debug(`Failed to resolve status update waiter: ${error.message}`);
+        }
+      }
+    }
+  }
+
   _rejectAllStatusWaiters(error) {
     for (const [datapointId, waiters] of this.statusWaiters.entries()) {
       for (const waiter of waiters) {
@@ -285,6 +305,15 @@ class MideaSerialBridge extends EventEmitter {
       }
     }
     this.statusWaiters.clear();
+
+    for (const waiter of this.statusUpdateWaiters) {
+      try {
+        waiter.reject(error);
+      } catch (rejectError) {
+        this.log.debug(`Failed to reject status update waiter: ${rejectError.message}`);
+      }
+    }
+    this.statusUpdateWaiters.clear();
   }
 
   _sendRequest(buffer, sequence, metadata = {}) {
@@ -418,36 +447,73 @@ class MideaSerialBridge extends EventEmitter {
     return { promise, cancel };
   }
 
+  _waitForStatusUpdate(options = {}) {
+    const { timeoutMs = 5000, minVersion = this.statusVersion } = options;
+
+    if (this.statusVersion > minVersion) {
+      return {
+        promise: Promise.resolve(this.statusVersion),
+        cancel: () => {},
+      };
+    }
+
+    let settled = false;
+    let timeoutHandle = null;
+    const waiter = {
+      minVersion,
+    };
+
+    const promise = new Promise((resolve, reject) => {
+      waiter.resolve = (version) => {
+        if (settled || version <= minVersion) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeoutHandle);
+        this.statusUpdateWaiters.delete(waiter);
+        resolve(version);
+      };
+
+      waiter.reject = (error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeoutHandle);
+        this.statusUpdateWaiters.delete(waiter);
+        reject(error);
+      };
+    });
+
+    if (timeoutMs > 0) {
+      timeoutHandle = setTimeout(() => {
+        waiter.reject(new Error('Status update timeout'));
+      }, timeoutMs);
+    }
+
+    this.statusUpdateWaiters.add(waiter);
+
+    const cancel = (error) => {
+      waiter.reject(error || new Error('Cancelled'));
+    };
+
+    return { promise, cancel };
+  }
+
   async query(datapointId, params = {}) {
-    const definition = REQUESTS[datapointId];
-    if (!definition || !definition.query) {
+    if (!REQUESTS[datapointId]) {
       throw new Error(`Datapoint ${datapointId} cannot be queried`);
     }
 
     const timeoutMs = typeof params.timeout === 'number' ? params.timeout : 5000;
     const baselineVersion = this.statusVersion;
-    const { promise: waitPromise, cancel } = this._waitForStatusValue(datapointId, {
-      timeoutMs,
-      requireFresh: true,
-      minVersion: baselineVersion,
-    });
-
-    const { buffer } = encodeFrame(definition.query, params);
     try {
-      await this._sendFrame(buffer, {
-        datapointId,
-        operation: 'query',
-        command: definition.query.command,
-      });
-    } catch (error) {
-      cancel(error);
-      waitPromise.catch(() => {});
-      throw error;
-    }
-
-    try {
-      const value = await waitPromise;
-      return value;
+      await this.requestStatus({ timeout: timeoutMs, baselineVersion });
+      const updated = this.statusValues.get(datapointId);
+      if (updated) {
+        return updated.value;
+      }
+      throw new Error(`Status value for ${datapointId} unavailable`);
     } catch (error) {
       if (this.statusValues.has(datapointId)) {
         const cached = this.statusValues.get(datapointId);
@@ -458,6 +524,50 @@ class MideaSerialBridge extends EventEmitter {
       }
       throw error;
     }
+  }
+
+  async requestStatus(params = {}) {
+    const timeoutMs = typeof params.timeout === 'number' ? params.timeout : 5000;
+    const baselineVersion =
+      typeof params.baselineVersion === 'number' ? params.baselineVersion : this.statusVersion;
+
+    if (this.statusVersion > baselineVersion) {
+      return Promise.resolve(this.statusVersion);
+    }
+
+    const { promise: waitPromise, cancel } = this._waitForStatusUpdate({
+      timeoutMs,
+      minVersion: baselineVersion,
+    });
+
+    try {
+      await this._sendStatusRequest();
+    } catch (error) {
+      cancel(error);
+      waitPromise.catch(() => {});
+      throw error;
+    }
+
+    return waitPromise;
+  }
+
+  _sendStatusRequest() {
+    const now = Date.now();
+    const minInterval = 200;
+    if (now - this._lastStatusRequestAt < minInterval) {
+      return Promise.resolve();
+    }
+
+    const { buffer } = encodeFrame(STATUS_REQUEST);
+    this._lastStatusRequestAt = now;
+
+    return this._sendFrame(buffer, {
+      operation: 'status query',
+      command: STATUS_REQUEST.command,
+    }).catch((error) => {
+      this._lastStatusRequestAt = 0;
+      throw error;
+    });
   }
 
   async set(datapointId, value, params = {}) {
@@ -480,6 +590,11 @@ class MideaSerialBridge extends EventEmitter {
         datapointId,
         operation: 'set',
         command: definition.set.command,
+      });
+      this._sendStatusRequest().catch((requestError) => {
+        this.log.debug(
+          `Failed to trigger status refresh after set ${datapointId}: ${requestError.message}`
+        );
       });
     } catch (error) {
       cancel(error);

--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -143,127 +143,73 @@ function decodeFrame(buffer) {
   };
 }
 
-function booleanParser(payload) {
-  return payload[0] === 1;
-}
-
-function numberParser(payload) {
-  if (!payload || payload.length === 0) {
-    return 0;
-  }
-
-  return payload.readInt8(0);
-}
-
-function temperatureParser(payload) {
-  if (!payload || payload.length === 0) {
-    return null;
-  }
-  return payload[0] / 2;
-}
+const STATUS_REQUEST = {
+  command: 0x41,
+  payloadBuilder: () => [0x01],
+};
 
 const REQUESTS = {
   power: {
-    query: {
-      command: 0x81,
-      payloadBuilder: () => [0x01],
-    },
+    usesStatus: true,
     set: {
       command: 0x11,
       payloadBuilder: ({ value }) => [value ? 0x01 : 0x00],
     },
-    parse: booleanParser,
   },
   mode: {
-    query: {
-      command: 0x82,
-      payloadBuilder: () => [0x02],
-    },
+    usesStatus: true,
     set: {
       command: 0x12,
       payloadBuilder: ({ value }) => [value & 0x0f],
     },
-    parse: numberParser,
   },
   targetTemperature: {
-    query: {
-      command: 0x83,
-      payloadBuilder: () => [0x03],
-    },
+    usesStatus: true,
     set: {
       command: 0x13,
       payloadBuilder: ({ value }) => [Math.round(value)],
     },
-    parse: numberParser,
   },
   indoorTemperature: {
-    query: {
-      command: 0x84,
-      payloadBuilder: () => [0x04],
-    },
-    parse: temperatureParser,
+    usesStatus: true,
   },
   outdoorTemperature: {
-    query: {
-      command: 0x85,
-      payloadBuilder: () => [0x05],
-    },
-    parse: temperatureParser,
+    usesStatus: true,
   },
   fanSpeed: {
-    query: {
-      command: 0x86,
-      payloadBuilder: () => [0x06],
-    },
+    usesStatus: true,
     set: {
       command: 0x16,
       payloadBuilder: ({ value }) => [value & 0x0f],
     },
-    parse: numberParser,
   },
   swingMode: {
-    query: {
-      command: 0x87,
-      payloadBuilder: () => [0x07],
-    },
+    usesStatus: true,
     set: {
       command: 0x17,
       payloadBuilder: ({ value }) => [value & 0x0f],
     },
-    parse: numberParser,
   },
   ecoMode: {
-    query: {
-      command: 0x88,
-      payloadBuilder: () => [0x08],
-    },
+    usesStatus: true,
     set: {
       command: 0x18,
       payloadBuilder: ({ value }) => [value ? 0x01 : 0x00],
     },
-    parse: booleanParser,
   },
   turboMode: {
-    query: {
-      command: 0x89,
-      payloadBuilder: () => [0x09],
-    },
+    usesStatus: true,
     set: {
       command: 0x19,
       payloadBuilder: ({ value }) => [value ? 0x01 : 0x00],
     },
-    parse: booleanParser,
   },
   sleepMode: {
-    query: {
-      command: 0x8a,
-      payloadBuilder: () => [0x0a],
-    },
+    usesStatus: true,
     set: {
       command: 0x1a,
       payloadBuilder: ({ value }) => [value ? 0x01 : 0x00],
     },
-    parse: booleanParser,
   },
 };
 
@@ -271,4 +217,5 @@ module.exports = {
   encodeFrame,
   decodeFrame,
   REQUESTS,
+  STATUS_REQUEST,
 };


### PR DESCRIPTION
## Summary
- add a dedicated status request frame and expose it from the protocol helper
- update the serial bridge to request status frames, track global waiters, and reuse cached values
- poll the bridge by requesting full status snapshots instead of per-datapoint queries

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d850277f9483258f8d089f15f09232