### PR TITLE
Fix parsing of 0xAC status frames

### DIFF
--- a/lib/status-parser.js
+++ b/lib/status-parser.js
@@ -1,63 +1,115 @@
 'use strict';
 
-function decodeTemperature(byte) {
+function decodeTemperature(byte, decimalNibble) {
   if (byte == null || byte === 0xff) {
     return null;
   }
 
-  const value = (byte - 80) / 2;
+  let value = (byte - 50) / 2;
   if (!Number.isFinite(value)) {
     return null;
   }
 
-  if (value < -40 || value > 80) {
+  if (decimalNibble != null && decimalNibble !== 0xf) {
+    const decimal = decimalNibble / 10;
+    if (value >= 0) {
+      value += decimal;
+    } else {
+      value -= decimal;
+    }
+  }
+
+  if (value < -50 || value > 100) {
     return null;
   }
 
-  return Math.round(value * 2) / 2;
+  return Math.round(value * 10) / 10;
 }
 
-function pickOutdoorTemperature(bytes) {
-  for (const byte of bytes) {
-    const temperature = decodeTemperature(byte);
-    if (temperature != null) {
-      return temperature;
-    }
+function mapFanSpeed(value) {
+  if (value == null) {
+    return null;
   }
-  return null;
+
+  if (value === 0 || value === 101 || value === 102) {
+    return 0; // auto / fixed
+  }
+
+  if (value <= 30) {
+    return 1; // low / silent
+  }
+
+  if (value <= 60) {
+    return 2; // medium
+  }
+
+  if (value <= 80) {
+    return 3; // high
+  }
+
+  return 4; // turbo or higher
 }
 
 function parse0xACStatus(payload) {
-  if (!payload || payload.length < 16) {
+  if (!payload || payload.length < 9) {
+    return null;
+  }
+
+  const data = payload.slice(7, payload.length - 1);
+  if (!data || data.length < 16) {
+    return null;
+  }
+
+  const messageType = data[0];
+  if (messageType !== 0xc0) {
     return null;
   }
 
   const values = {};
 
-  const flags = payload[5] ?? 0;
+  const flags = data[1] ?? 0;
   values.power = (flags & 0x01) === 0x01;
-  values.mode = (flags >> 1) & 0x07;
 
-  const targetRaw = payload[6] & 0x1f;
-  values.targetTemperature = 8 + targetRaw;
+  const modeAndTarget = data[2] ?? 0;
+  values.mode = (modeAndTarget & 0xe0) >> 5;
+  values.targetTemperature = 16 + (modeAndTarget & 0x0f) + ((modeAndTarget & 0x10) >> 4) * 0.5;
 
-  values.fanSpeed = payload[7] & 0x0f;
-  values.swingMode = payload[8] & 0x0f;
+  const fanSpeedRaw = data[3] & 0x7f;
+  const mappedFanSpeed = mapFanSpeed(fanSpeedRaw);
+  if (mappedFanSpeed != null) {
+    values.fanSpeed = mappedFanSpeed;
+  }
 
-  const indoorTemperature = decodeTemperature(payload[10]);
+  const swingByte = data[7] ?? 0;
+  const updownFan = (swingByte & 0x0c) === 0x0c;
+  const leftrightFan = (swingByte & 0x03) === 0x03;
+  let swingMode = 0;
+  if (updownFan && leftrightFan) {
+    swingMode = 3;
+  } else if (updownFan) {
+    swingMode = 1;
+  } else if (leftrightFan) {
+    swingMode = 2;
+  }
+  values.swingMode = swingMode;
+
+  const featureByte8 = data[8] ?? 0;
+  const featureByte9 = data[9] ?? 0;
+  const featureByte10 = data[10] ?? 0;
+  const turbo2 = (featureByte8 & 0x20) === 0x20;
+  values.ecoMode = (featureByte9 & 0x10) === 0x10;
+  values.turboMode = (featureByte10 & 0x02) === 0x02 || turbo2;
+  values.sleepMode = (featureByte10 & 0x01) === 0x01;
+
+  const indoorTemperature = decodeTemperature(data[11], data[15] & 0x0f);
   if (indoorTemperature != null) {
     values.indoorTemperature = indoorTemperature;
   }
 
-  const outdoorTemperature = pickOutdoorTemperature([payload[11], payload[12], payload[13]]);
+  const outdoorTemperature = decodeTemperature(data[12], (data[15] & 0xf0) >> 4);
   if (outdoorTemperature != null) {
     values.outdoorTemperature = outdoorTemperature;
   }
-
-  const featureFlags = payload[15] ?? 0;
-  values.ecoMode = (featureFlags & 0x02) === 0x02;
-  values.turboMode = (featureFlags & 0x04) === 0x04;
-  values.sleepMode = (featureFlags & 0x08) === 0x08;
 
   return {
     command: 0xac,


### PR DESCRIPTION
## Summary
- align 0xAC status parsing with the node-mideahvac C0 frame layout and ignore non-status messages
- improve fan speed and temperature decoding, including decimal handling for indoor and outdoor readings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d85511d66c8325b17fb503a8c8ed1b