### PR TITLE
Add option to mute device beep when sending commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.0.2 (2025-09-27)
 
 * normalize and persist adapter configuration to keep the host field stable in the admin UI
+* add configuration option to mute the device beep when sending commands
 
 ## 0.0.1 (2025-09-27)
 

--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -8,6 +8,8 @@
   "pollingInterval_help": "Fallback polling interval in seconds if no individual interval is set.",
   "reconnectInterval": "Reconnect interval",
   "reconnectInterval_help": "Time in seconds before trying to reconnect after a disconnection.",
+  "beep": "Signalton bei Befehlen",
+  "beep_help": "Deaktivieren, um das Piepen des Geräts bei Befehlen zu verhindern.",
   "polling": "Polling",
   "pollingRequests": "Befehle",
   "pollingRequests_help": "Wählen Sie aus, welche Befehle zyklisch ausgeführt werden und konfigurieren Sie individuelle Intervalle.",

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -8,6 +8,8 @@
   "pollingInterval_help": "Fallback polling interval in seconds if no individual interval is set.",
   "reconnectInterval": "Reconnect interval",
   "reconnectInterval_help": "Time in seconds before trying to reconnect after a disconnection.",
+  "beep": "Device beep on commands",
+  "beep_help": "Disable to prevent the indoor unit from beeping when commands are sent.",
   "polling": "Polling",
   "pollingRequests": "Commands",
   "pollingRequests_help": "Select which commands should be executed cyclically and configure individual intervals.",

--- a/admin/i18n/es/translations.json
+++ b/admin/i18n/es/translations.json
@@ -8,6 +8,8 @@
   "pollingInterval_help": "Fallback polling interval in seconds if no individual interval is set.",
   "reconnectInterval": "Reconnect interval",
   "reconnectInterval_help": "Time in seconds before trying to reconnect after a disconnection.",
+  "beep": "Device beep on commands",
+  "beep_help": "Disable to prevent the indoor unit from beeping when commands are sent.",
   "polling": "Polling",
   "pollingRequests": "Commands",
   "pollingRequests_help": "Select which commands should be executed cyclically and configure individual intervals.",

--- a/admin/i18n/fr/translations.json
+++ b/admin/i18n/fr/translations.json
@@ -8,6 +8,8 @@
   "pollingInterval_help": "Fallback polling interval in seconds if no individual interval is set.",
   "reconnectInterval": "Reconnect interval",
   "reconnectInterval_help": "Time in seconds before trying to reconnect after a disconnection.",
+  "beep": "Device beep on commands",
+  "beep_help": "Disable to prevent the indoor unit from beeping when commands are sent.",
   "polling": "Polling",
   "pollingRequests": "Commands",
   "pollingRequests_help": "Select which commands should be executed cyclically and configure individual intervals.",

--- a/admin/i18n/it/translations.json
+++ b/admin/i18n/it/translations.json
@@ -8,6 +8,8 @@
   "pollingInterval_help": "Fallback polling interval in seconds if no individual interval is set.",
   "reconnectInterval": "Reconnect interval",
   "reconnectInterval_help": "Time in seconds before trying to reconnect after a disconnection.",
+  "beep": "Device beep on commands",
+  "beep_help": "Disable to prevent the indoor unit from beeping when commands are sent.",
   "polling": "Polling",
   "pollingRequests": "Commands",
   "pollingRequests_help": "Select which commands should be executed cyclically and configure individual intervals.",

--- a/admin/i18n/nl/translations.json
+++ b/admin/i18n/nl/translations.json
@@ -8,6 +8,8 @@
   "pollingInterval_help": "Fallback polling interval in seconds if no individual interval is set.",
   "reconnectInterval": "Reconnect interval",
   "reconnectInterval_help": "Time in seconds before trying to reconnect after a disconnection.",
+  "beep": "Device beep on commands",
+  "beep_help": "Disable to prevent the indoor unit from beeping when commands are sent.",
   "polling": "Polling",
   "pollingRequests": "Commands",
   "pollingRequests_help": "Select which commands should be executed cyclically and configure individual intervals.",

--- a/admin/i18n/pl/translations.json
+++ b/admin/i18n/pl/translations.json
@@ -8,6 +8,8 @@
   "pollingInterval_help": "Fallback polling interval in seconds if no individual interval is set.",
   "reconnectInterval": "Reconnect interval",
   "reconnectInterval_help": "Time in seconds before trying to reconnect after a disconnection.",
+  "beep": "Device beep on commands",
+  "beep_help": "Disable to prevent the indoor unit from beeping when commands are sent.",
   "polling": "Polling",
   "pollingRequests": "Commands",
   "pollingRequests_help": "Select which commands should be executed cyclically and configure individual intervals.",

--- a/admin/i18n/pt/translations.json
+++ b/admin/i18n/pt/translations.json
@@ -8,6 +8,8 @@
   "pollingInterval_help": "Fallback polling interval in seconds if no individual interval is set.",
   "reconnectInterval": "Reconnect interval",
   "reconnectInterval_help": "Time in seconds before trying to reconnect after a disconnection.",
+  "beep": "Device beep on commands",
+  "beep_help": "Disable to prevent the indoor unit from beeping when commands are sent.",
   "polling": "Polling",
   "pollingRequests": "Commands",
   "pollingRequests_help": "Select which commands should be executed cyclically and configure individual intervals.",

--- a/admin/i18n/ru/translations.json
+++ b/admin/i18n/ru/translations.json
@@ -8,6 +8,8 @@
   "pollingInterval_help": "Fallback polling interval in seconds if no individual interval is set.",
   "reconnectInterval": "Reconnect interval",
   "reconnectInterval_help": "Time in seconds before trying to reconnect after a disconnection.",
+  "beep": "Device beep on commands",
+  "beep_help": "Disable to prevent the indoor unit from beeping when commands are sent.",
   "polling": "Polling",
   "pollingRequests": "Commands",
   "pollingRequests_help": "Select which commands should be executed cyclically and configure individual intervals.",

--- a/admin/i18n/uk/translations.json
+++ b/admin/i18n/uk/translations.json
@@ -8,6 +8,8 @@
   "pollingInterval_help": "Fallback polling interval in seconds if no individual interval is set.",
   "reconnectInterval": "Reconnect interval",
   "reconnectInterval_help": "Time in seconds before trying to reconnect after a disconnection.",
+  "beep": "Device beep on commands",
+  "beep_help": "Disable to prevent the indoor unit from beeping when commands are sent.",
   "polling": "Polling",
   "pollingRequests": "Commands",
   "pollingRequests_help": "Select which commands should be executed cyclically and configure individual intervals.",

--- a/admin/i18n/zh-cn/translations.json
+++ b/admin/i18n/zh-cn/translations.json
@@ -8,6 +8,8 @@
   "pollingInterval_help": "Fallback polling interval in seconds if no individual interval is set.",
   "reconnectInterval": "Reconnect interval",
   "reconnectInterval_help": "Time in seconds before trying to reconnect after a disconnection.",
+  "beep": "Device beep on commands",
+  "beep_help": "Disable to prevent the indoor unit from beeping when commands are sent.",
   "polling": "Polling",
   "pollingRequests": "Commands",
   "pollingRequests_help": "Select which commands should be executed cyclically and configure individual intervals.",

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -52,6 +52,16 @@
           "xs": 12,
           "sm": 6,
           "md": 4
+        },
+        "beep": {
+          "type": "checkbox",
+          "label": "beep",
+          "attr": "beep",
+          "default": true,
+          "help": "beep_help",
+          "xs": 12,
+          "sm": 6,
+          "md": 4
         }
       }
     },
@@ -113,6 +123,8 @@
     "pollingInterval_help": "pollingInterval_help",
     "reconnectInterval": "reconnectInterval",
     "reconnectInterval_help": "reconnectInterval_help",
+    "beep": "beep",
+    "beep_help": "beep_help",
     "polling": "polling",
     "pollingRequests": "pollingRequests",
     "pollingRequests_help": "pollingRequests_help",

--- a/io-package.json
+++ b/io-package.json
@@ -63,6 +63,7 @@
     "port": 23,
     "pollingInterval": 60,
     "reconnectInterval": 10,
+    "beep": true,
     "customPolling": false,
     "pollingRequests": []
   },

--- a/lib/midea-serial-bridge.js
+++ b/lib/midea-serial-bridge.js
@@ -63,6 +63,7 @@ class MideaSerialBridge extends EventEmitter {
     this.host = options.host;
     this.port = options.port || 23;
     this.log = options.log;
+    this.beepOnCommand = options.beepOnCommand !== false;
 
     this.device = null;
     this.connected = false;
@@ -165,7 +166,7 @@ class MideaSerialBridge extends EventEmitter {
       throw new Error(`Unsupported datapoint ${datapointId}`);
     }
 
-    const status = await this.device.setStatus(payload);
+    const status = await this.device.setStatus(this._applyBeepPreference(payload));
     const mapped = this._handleStatus(status);
 
     if (!mapped || mapped[datapointId] === undefined) {
@@ -399,6 +400,18 @@ class MideaSerialBridge extends EventEmitter {
       default:
         return {};
     }
+  }
+
+  _applyBeepPreference(payload) {
+    if (!payload || typeof payload !== 'object') {
+      return payload;
+    }
+
+    if (this.beepOnCommand === false && payload.beep === undefined) {
+      return { ...payload, beep: false };
+    }
+
+    return payload;
   }
 
   _fallbackValue(datapointId, value) {

--- a/main.js
+++ b/main.js
@@ -77,6 +77,7 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
         port: Number(this.config.port) || 23,
         reconnectInterval: (Number(this.config.reconnectInterval) || 10) * 1000,
         log: this.log,
+        beepOnCommand: this.config.beep !== false,
       });
 
       this.bridge.on('connected', () => {


### PR DESCRIPTION
## Summary
- add an admin checkbox that lets users disable the device beep for adapter commands
- propagate the configuration to the bridge so `beep: false` is sent when commands are executed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d85fa3e4448325b15c2edbab6ac9f5