### PR TITLE
Fix admin JSON config and support JSON command state

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This adapter allows you to control Midea HVAC units locally using the well known
 * Connect to a TCP serial bridge (default port 23)
 * Poll the device for specific datapoints at configurable intervals
 * Write commands from ioBroker states back to the air conditioner
+* Send raw JSON commands to the bridge for advanced control scenarios
 * Automatic reconnects and error handling
 * JSON based configuration UI similar to [ioBroker.gira-endpoint](https://github.com/dosordie/ioBroker.gira-endpoint)
 
@@ -43,6 +44,16 @@ The following datapoints are available out of the box:
 | `sleepMode` | Sleep mode | ✓ | ✓ |
 
 Whenever you change a writable state in ioBroker the adapter forwards the command to the bridge immediately.
+
+### JSON command input
+
+For advanced use cases you can send arbitrary command payloads to the serial bridge through the state `control.command`. The state expects a JSON object string that is passed as-is to the bridge (with the adapter optionally adding `"beep": false` when the configuration disables beeps). Example:
+
+```
+{"beep": false, "temperatureSetpoint": 30}
+```
+
+Successful commands are acknowledged automatically and the resulting status update is reflected in the other datapoints.
 
 ## Known limitations
 

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -1,11 +1,11 @@
 {
   "type": "tabs",
-  "items": {
-    "connection": {
+  "items": [
+    {
       "type": "panel",
       "label": "general",
-      "items": {
-        "host": {
+      "items": [
+        {
           "type": "text",
           "label": "host",
           "attr": "host",
@@ -15,7 +15,7 @@
           "sm": 6,
           "md": 4
         },
-        "port": {
+        {
           "type": "number",
           "label": "port",
           "attr": "port",
@@ -27,7 +27,7 @@
           "sm": 6,
           "md": 4
         },
-        "pollingInterval": {
+        {
           "type": "number",
           "label": "pollingInterval",
           "attr": "pollingInterval",
@@ -40,7 +40,7 @@
           "sm": 6,
           "md": 4
         },
-        "reconnectInterval": {
+        {
           "type": "number",
           "label": "reconnectInterval",
           "attr": "reconnectInterval",
@@ -53,7 +53,7 @@
           "sm": 6,
           "md": 4
         },
-        "beep": {
+        {
           "type": "checkbox",
           "label": "beep",
           "attr": "beep",
@@ -63,13 +63,13 @@
           "sm": 6,
           "md": 4
         }
-      }
+      ]
     },
-    "polling": {
+    {
       "type": "panel",
       "label": "polling",
-      "items": {
-        "customPolling": {
+      "items": [
+        {
           "type": "checkbox",
           "label": "customPolling",
           "attr": "customPolling",
@@ -77,7 +77,7 @@
           "help": "customPolling_help",
           "xs": 12
         },
-        "requests": {
+        {
           "type": "table",
           "attr": "pollingRequests",
           "label": "pollingRequests",
@@ -110,9 +110,9 @@
             }
           ]
         }
-      }
+      ]
     }
-  },
+  ],
   "translations": {
     "general": "general",
     "host": "host",

--- a/lib/midea-serial-bridge.js
+++ b/lib/midea-serial-bridge.js
@@ -180,6 +180,20 @@ class MideaSerialBridge extends EventEmitter {
     return mapped;
   }
 
+  async sendCommand(command) {
+    if (!this.device) {
+      throw new Error('Bridge not connected');
+    }
+
+    if (!command || typeof command !== 'object' || Array.isArray(command)) {
+      throw new Error('Command payload must be an object');
+    }
+
+    const payload = this._applyBeepPreference({ ...command });
+    const status = await this.device.setStatus(payload);
+    return this._handleStatus(status);
+  }
+
   _bindDeviceEvents() {
     this.device.on('connected', () => {
       this.connected = true;


### PR DESCRIPTION
## Summary
- restructure the Admin jsonConfig to match the current schema validation
- add a writable control.command state that forwards raw JSON command payloads to the serial bridge
- expose a sendCommand helper on the bridge and document the new capability in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8e00d38f08325a663ff50591bb1f6