### PR TITLE
Fix frost protection mode heat check

### DIFF
--- a/lib/node-mideahvac/lib/ac.js
+++ b/lib/node-mideahvac/lib/ac.js
@@ -252,7 +252,9 @@ module.exports = class extends EventEmitter {
             break;
 
           case 'frostProtectionMode': // Requires capability frostProtectionMode and only available when mode is heat
-            if (status.mode !== 'heat' && properties.mode !== 'heat') {
+            const isHeatMode = value => value === 'heat' || value === 4;
+
+            if (!isHeatMode(status.mode) && !isHeatMode(properties.mode)) {
               return reject(new errors.OutOfRangeError('frostProtection capability is only available in heat mode'));
             }
 


### PR DESCRIPTION
## Summary
- allow frost protection mode to be toggled when the adapter reports the heat mode using its numeric value

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68de346ed7e8832591112ab5c93ff47a