### PR TITLE
Avoid rejecting frost protection outside heat mode

### DIFF
--- a/lib/node-mideahvac/lib/ac.js
+++ b/lib/node-mideahvac/lib/ac.js
@@ -251,17 +251,24 @@ module.exports = class extends EventEmitter {
             status.fanSpeed = typeof properties[property] === 'number' ? properties[property] : fanSpeed[properties[property]];
             break;
 
-          case 'frostProtectionMode': // Requires capability frostProtectionMode and only available when mode is heat
+          case 'frostProtectionMode': { // Requires capability frostProtectionMode and only available when mode is heat
             const isHeatMode = value => value === 'heat' || value === 4;
+            const requestedValue = properties[property] === true;
 
             if (!isHeatMode(status.mode) && !isHeatMode(properties.mode)) {
-              return reject(new errors.OutOfRangeError('frostProtection capability is only available in heat mode'));
+              if (requestedValue) {
+                logger.warn('AC.setStatus: Ignoring frost protection activation because the device is not in heat mode');
+              }
+
+              status.frostProtectionMode = false;
+              break;
             }
 
-            logger.debug(`AC.setStatus: Set frost protection mode to ${properties[property] === true}`);
+            logger.debug(`AC.setStatus: Set frost protection mode to ${requestedValue}`);
 
-            status.frostProtectionMode = properties[property] === true;
+            status.frostProtectionMode = requestedValue;
             break;
+          }
 
           case 'humiditySetpoint':
             if (properties[property] < 35 || properties[property] > 85) {


### PR DESCRIPTION
## Summary
- prevent frostProtectionMode writes from erroring when the device is not in heat mode
- log a warning and keep frost protection disabled instead of throwing an exception

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de3600bdf08325a2390a69277f2ceb