### PR TITLE
Add toggle support to JSON commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ For advanced use cases you can send arbitrary command payloads to the serial bri
 {"beep": false, "temperatureSetpoint": 30}
 ```
 
+When sending boolean properties you can pass the string value `"toggle"` to invert the cached state of supported flags (`power`, `ecoMode`, `frostProtectionMode`, `turboMode`, `sleepMode`). This allows commands such as:
+
+```
+{"turboMode": "toggle"}
+```
+
 Successful commands are acknowledged automatically and the resulting status update is reflected in the other datapoints.
 
 ## Known limitations

--- a/lib/midea-serial-bridge.js
+++ b/lib/midea-serial-bridge.js
@@ -160,7 +160,11 @@ class MideaSerialBridge extends EventEmitter {
       throw new Error('Command payload must be an object');
     }
 
-    const payload = this._applyBeepPreference({ ...command });
+    const payload = this._applyBeepPreference(
+      this._resolveToggleValues({
+        ...command,
+      })
+    );
     const status = await this.device.setStatus(payload);
     const mapped = this._handleStatus(status);
 
@@ -805,6 +809,53 @@ class MideaSerialBridge extends EventEmitter {
     }
 
     return payload;
+  }
+
+  _resolveToggleValues(payload) {
+    if (!payload || typeof payload !== 'object') {
+      return payload;
+    }
+
+    const result = { ...payload };
+    for (const [property, value] of Object.entries(result)) {
+      if (!this._isToggleValue(value)) {
+        continue;
+      }
+
+      const statusKey = this._resolveToggleStatusKey(property);
+      if (!statusKey) {
+        this.log.debug(`Ignoring toggle for unsupported property ${property}`);
+        continue;
+      }
+
+      const currentValue = this.statusCache[statusKey];
+      result[property] = !toBoolean(currentValue);
+    }
+
+    return result;
+  }
+
+  _isToggleValue(value) {
+    if (typeof value !== 'string') {
+      return false;
+    }
+
+    return value.trim().toLowerCase() === 'toggle';
+  }
+
+  _resolveToggleStatusKey(property) {
+    switch (property) {
+      case 'power':
+      case 'powerOn':
+        return 'power';
+      case 'ecoMode':
+      case 'frostProtectionMode':
+      case 'turboMode':
+      case 'sleepMode':
+        return property;
+      default:
+        return undefined;
+    }
   }
 
   _fallbackValue(datapointId, value) {


### PR DESCRIPTION
## Summary
- allow JSON command payloads to use the "toggle" keyword for boolean flags
- derive toggle values from the cached device status before sending commands
- document the toggle behaviour in the README

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de3c2453ec8325afc042dc535237e1