### PR TITLE
Improve boolean normalization and status parsing

### DIFF
--- a/lib/midea-serial-bridge.js
+++ b/lib/midea-serial-bridge.js
@@ -18,7 +18,20 @@ const {
 } = require('./value-mappings');
 
 function toBoolean(value) {
-  return value === true || value === 1 || value === 'true';
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) {
+      return false;
+    }
+    if (normalized === 'true' || normalized === '1') {
+      return true;
+    }
+    if (normalized === 'false' || normalized === '0') {
+      return false;
+    }
+  }
+
+  return value === true || value === 1;
 }
 
 class MideaSerialBridge extends EventEmitter {
@@ -219,9 +232,14 @@ class MideaSerialBridge extends EventEmitter {
   _mapStatus(status) {
     const mapped = {};
 
-    if (status.powerOn !== undefined) {
-      mapped.power = !!status.powerOn;
-    }
+    const assignBoolean = (sourceKey, targetKey = sourceKey) => {
+      if (status[sourceKey] === undefined) {
+        return;
+      }
+      mapped[targetKey] = toBoolean(status[sourceKey]);
+    };
+
+    assignBoolean('powerOn', 'power');
 
     if (status.mode !== undefined) {
       const normalized = this._normalizeModeFromStatus(status.mode);
@@ -231,25 +249,19 @@ class MideaSerialBridge extends EventEmitter {
       }
     }
 
-    if (status.temperatureSetpoint !== undefined) {
-      const parsed = Number(status.temperatureSetpoint);
-      if (!Number.isNaN(parsed)) {
-        mapped.targetTemperature = parsed;
-      }
+    const targetTemperature = this._coerceFiniteNumber(status.temperatureSetpoint);
+    if (targetTemperature !== undefined) {
+      mapped.targetTemperature = targetTemperature;
     }
 
-    if (status.indoorTemperature !== undefined && status.indoorTemperature !== null) {
-      const parsed = Number(status.indoorTemperature);
-      if (!Number.isNaN(parsed)) {
-        mapped.indoorTemperature = parsed;
-      }
+    const indoorTemperature = this._coerceFiniteNumber(status.indoorTemperature);
+    if (indoorTemperature !== undefined) {
+      mapped.indoorTemperature = indoorTemperature;
     }
 
-    if (status.outdoorTemperature !== undefined && status.outdoorTemperature !== null) {
-      const parsed = Number(status.outdoorTemperature);
-      if (!Number.isNaN(parsed)) {
-        mapped.outdoorTemperature = parsed;
-      }
+    const outdoorTemperature = this._coerceFiniteNumber(status.outdoorTemperature);
+    if (outdoorTemperature !== undefined) {
+      mapped.outdoorTemperature = outdoorTemperature;
     }
 
     if (status.fanSpeed !== undefined) {
@@ -266,11 +278,11 @@ class MideaSerialBridge extends EventEmitter {
       const up =
         status.updownFan === undefined
           ? ['vertical', 'both'].includes(cachedSwingName)
-          : !!status.updownFan;
+          : toBoolean(status.updownFan);
       const left =
         status.leftrightFan === undefined
           ? ['horizontal', 'both'].includes(cachedSwingName)
-          : !!status.leftrightFan;
+          : toBoolean(status.leftrightFan);
       const normalized = this._normalizeSwingFromFlags(up, left);
       const formatted = this._formatSwingValue(normalized);
       if (formatted !== undefined) {
@@ -278,27 +290,14 @@ class MideaSerialBridge extends EventEmitter {
       }
     }
 
-    if (status.ecoMode !== undefined) {
-      mapped.ecoMode = !!status.ecoMode;
-    }
+    assignBoolean('ecoMode');
+    assignBoolean('frostProtectionMode');
+    assignBoolean('turboMode');
+    assignBoolean('sleepMode');
 
-    if (status.frostProtectionMode !== undefined) {
-      mapped.frostProtectionMode = !!status.frostProtectionMode;
-    }
-
-    if (status.turboMode !== undefined) {
-      mapped.turboMode = !!status.turboMode;
-    }
-
-    if (status.sleepMode !== undefined) {
-      mapped.sleepMode = !!status.sleepMode;
-    }
-
-    if (status.humiditySetpoint !== undefined) {
-      const parsed = Number(status.humiditySetpoint);
-      if (!Number.isNaN(parsed) && parsed >= 35 && parsed <= 85) {
-        mapped.humiditySetpoint = parsed;
-      }
+    const humiditySetpoint = this._coerceFiniteNumber(status.humiditySetpoint);
+    if (humiditySetpoint !== undefined && humiditySetpoint >= 35 && humiditySetpoint <= 85) {
+      mapped.humiditySetpoint = humiditySetpoint;
     }
 
     if (status.temperatureUnit !== undefined) {
@@ -624,8 +623,8 @@ class MideaSerialBridge extends EventEmitter {
       value.updownFan !== undefined &&
       value.leftrightFan !== undefined
     ) {
-      const up = !!value.updownFan;
-      const left = !!value.leftrightFan;
+      const up = toBoolean(value.updownFan);
+      const left = toBoolean(value.leftrightFan);
       return this._normalizeSwingFromFlags(up, left);
     }
 
@@ -719,6 +718,15 @@ class MideaSerialBridge extends EventEmitter {
 
   _shouldUseNumericValue(datapointId) {
     return !!(this.valueRepresentation && this.valueRepresentation[datapointId]);
+  }
+
+  _coerceFiniteNumber(value) {
+    if (value === null || value === undefined || value === '') {
+      return undefined;
+    }
+
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : undefined;
   }
 
   _encodeSwingMode(up, left) {
@@ -879,12 +887,11 @@ class MideaSerialBridge extends EventEmitter {
       case 'frostProtectionMode':
         return toBoolean(value);
       case 'targetTemperature': {
-        const numeric = Number(value);
-        return Number.isNaN(numeric) ? undefined : numeric;
+        return this._coerceFiniteNumber(value);
       }
       case 'humiditySetpoint': {
-        const numeric = Number(value);
-        return Number.isNaN(numeric) ? undefined : Math.round(numeric);
+        const numeric = this._coerceFiniteNumber(value);
+        return numeric === undefined ? undefined : Math.round(numeric);
       }
       case 'temperatureUnit':
         return this._convertTemperatureUnitValue(value);


### PR DESCRIPTION
## Summary
- replace the adapter's bespoke deep-clone/equality helpers with a structuredClone-based utility and Node's isDeepStrictEqual
- normalize boolean configuration, state write, and state read values in a single helper to avoid misinterpreting string or numeric flags
- harden the serial bridge status mapper by reusing consistent boolean conversion, centralizing numeric coercion, and improving swing handling fallbacks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de438e78f48325af496a14e545df81