### PR TITLE
Update adapter logo to stylized M

### DIFF
--- a/admin/midea-serialbridge.svg
+++ b/admin/midea-serialbridge.svg
@@ -6,8 +6,9 @@
     </linearGradient>
   </defs>
   <rect width="128" height="128" rx="20" fill="url(#grad)"/>
-  <g fill="#ffffff">
-    <path d="M40 64a24 24 0 0148 0 24 24 0 01-48 0zm24-14a14 14 0 1014 14A14 14 0 0064 50z" opacity="0.85"/>
-    <path d="M64 30a6 6 0 016 6v8a6 6 0 01-12 0v-8a6 6 0 016-6zm0 48a6 6 0 016 6v8a6 6 0 01-12 0v-8a6 6 0 016-6zm26-26a6 6 0 016 6h8a6 6 0 010 12h-8a6 6 0 01-12 0 6 6 0 016-6zM32 64a6 6 0 016-6h-8a6 6 0 000 12h8a6 6 0 01-6-6z"/>
+  <g fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M92 48A28 28 0 1 0 92 80" stroke-width="6"/>
+    <path d="M34 78V52l12 22 10-20 10 20 12-22v26" stroke-width="6"/>
   </g>
+  <circle cx="102" cy="68" r="6" fill="#ffffff"/>
 </svg>


### PR DESCRIPTION
## Summary
- redesign the adapter logo with a stylized Midea-inspired "M" while keeping the existing blue gradient palette

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de790c15988325a56229424bfc9216