### PR TITLE
Add Midea AC Group 5 polling

### DIFF
--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -36,5 +36,6 @@
   "swingModeAsNumber_help": "Stellt den Swing-Zustand als numerische Codes statt beschreibender Texte bereit und akzeptiert ihn so.",
   "getStatus": "Status (0x41)",
   "getCapabilities": "Fähigkeiten (0xB5)",
-  "getPowerUsage": "Energieverbrauch (0x41/Energie)"
+  "getPowerUsage": "Energieverbrauch (0x41/Energie)",
+  "getGroup5Data": "Group-5-Daten (0x41/Gruppe 5)"
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -36,5 +36,6 @@
   "swingModeAsNumber_help": "Expose and accept the swing mode state as numeric codes instead of descriptive strings.",
   "getStatus": "Status (0x41)",
   "getCapabilities": "Capabilities (0xB5)",
-  "getPowerUsage": "Power usage (0x41/energy)"
+  "getPowerUsage": "Power usage (0x41/energy)",
+  "getGroup5Data": "Group 5 data (0x41/group 5)"
 }

--- a/admin/i18n/es/translations.json
+++ b/admin/i18n/es/translations.json
@@ -36,5 +36,6 @@
   "getStatus": "Status (0x41)",
   "getCapabilities": "Capabilities (0xB5)",
   "getPowerUsage": "Power usage (0x41/energy)",
-  "options": "Options"
+  "options": "Options",
+  "getGroup5Data": "Group 5 data (0x41/group 5)"
 }

--- a/admin/i18n/fr/translations.json
+++ b/admin/i18n/fr/translations.json
@@ -36,5 +36,6 @@
   "getStatus": "Status (0x41)",
   "getCapabilities": "Capabilities (0xB5)",
   "getPowerUsage": "Power usage (0x41/energy)",
-  "options": "Options"
+  "options": "Options",
+  "getGroup5Data": "Group 5 data (0x41/group 5)"
 }

--- a/admin/i18n/it/translations.json
+++ b/admin/i18n/it/translations.json
@@ -36,5 +36,6 @@
   "getStatus": "Status (0x41)",
   "getCapabilities": "Capabilities (0xB5)",
   "getPowerUsage": "Power usage (0x41/energy)",
-  "options": "Options"
+  "options": "Options",
+  "getGroup5Data": "Group 5 data (0x41/group 5)"
 }

--- a/admin/i18n/nl/translations.json
+++ b/admin/i18n/nl/translations.json
@@ -36,5 +36,6 @@
   "getStatus": "Status (0x41)",
   "getCapabilities": "Capabilities (0xB5)",
   "getPowerUsage": "Power usage (0x41/energy)",
-  "options": "Options"
+  "options": "Options",
+  "getGroup5Data": "Group 5 data (0x41/group 5)"
 }

--- a/admin/i18n/pl/translations.json
+++ b/admin/i18n/pl/translations.json
@@ -36,5 +36,6 @@
   "getStatus": "Status (0x41)",
   "getCapabilities": "Capabilities (0xB5)",
   "getPowerUsage": "Power usage (0x41/energy)",
-  "options": "Options"
+  "options": "Options",
+  "getGroup5Data": "Group 5 data (0x41/group 5)"
 }

--- a/admin/i18n/pt/translations.json
+++ b/admin/i18n/pt/translations.json
@@ -36,5 +36,6 @@
   "getStatus": "Status (0x41)",
   "getCapabilities": "Capabilities (0xB5)",
   "getPowerUsage": "Power usage (0x41/energy)",
-  "options": "Options"
+  "options": "Options",
+  "getGroup5Data": "Group 5 data (0x41/group 5)"
 }

--- a/admin/i18n/ru/translations.json
+++ b/admin/i18n/ru/translations.json
@@ -36,5 +36,6 @@
   "getStatus": "Status (0x41)",
   "getCapabilities": "Capabilities (0xB5)",
   "getPowerUsage": "Power usage (0x41/energy)",
-  "options": "Options"
+  "options": "Options",
+  "getGroup5Data": "Group 5 data (0x41/group 5)"
 }

--- a/admin/i18n/uk/translations.json
+++ b/admin/i18n/uk/translations.json
@@ -36,5 +36,6 @@
   "getStatus": "Status (0x41)",
   "getCapabilities": "Capabilities (0xB5)",
   "getPowerUsage": "Power usage (0x41/energy)",
-  "options": "Options"
+  "options": "Options",
+  "getGroup5Data": "Group 5 data (0x41/group 5)"
 }

--- a/admin/i18n/zh-cn/translations.json
+++ b/admin/i18n/zh-cn/translations.json
@@ -36,5 +36,6 @@
   "getStatus": "Status (0x41)",
   "getCapabilities": "Capabilities (0xB5)",
   "getPowerUsage": "Power usage (0x41/energy)",
-  "options": "Options"
+  "options": "Options",
+  "getGroup5Data": "Group 5 data (0x41/group 5)"
 }

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -320,6 +320,13 @@
                     "en": "Power usage (0x41/energy)",
                     "de": "Energieverbrauch (0x41/Energie)"
                   }
+                },
+                {
+                  "value": "getGroup5Data",
+                  "label": {
+                    "en": "Group 5 data (0x41/group 5)",
+                    "de": "Group-5-Daten (0x41/Gruppe 5)"
+                  }
                 }
               ]
             },

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "name": "midea-serialbridge",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "titleLang": {
       "en": "Midea Serial Bridge",
       "de": "Midea Serial Bridge",
@@ -42,13 +42,20 @@
       "config": "json"
     },
     "readme": "https://github.com/dosordie/ioBroker.midea-serialbridge/blob/main/README.md",
-    "keywords": ["midea", "hvac", "serial", "climate"],
+    "keywords": [
+      "midea",
+      "hvac",
+      "serial",
+      "climate"
+    ],
     "dependencies": [
       {
         "js-controller": ">=5.0.19"
       }
     ],
-    "authors": ["dosordie <info@dosordie.de>"],
+    "authors": [
+      "dosordie <info@dosordie.de>"
+    ],
     "licenseInformation": {
       "license": "MIT",
       "url": "https://github.com/dosordie/ioBroker.midea-serialbridge/blob/main/LICENSE",

--- a/lib/datapoints.js
+++ b/lib/datapoints.js
@@ -185,6 +185,34 @@ const DATA_POINTS = [
     unit: 'kWh',
     readOnly: true,
   },
+  {
+    id: 'indoorHumidity',
+    channel: 'sensors',
+    name: 'Indoor humidity',
+    role: 'value.humidity',
+    type: 'number',
+    unit: '%',
+    min: 0,
+    max: 100,
+    readOnly: true,
+  },
+  {
+    id: 'outdoorFanSpeed',
+    channel: 'sensors',
+    name: 'Outdoor fan speed',
+    role: 'value.speed',
+    type: 'number',
+    unit: 'rpm',
+    readOnly: true,
+  },
+  {
+    id: 'defrostActive',
+    channel: 'sensors',
+    name: 'Defrost active',
+    role: 'indicator',
+    type: 'boolean',
+    readOnly: true,
+  },
 ];
 
 module.exports = {

--- a/lib/midea-serial-bridge.js
+++ b/lib/midea-serial-bridge.js
@@ -146,6 +146,19 @@ class MideaSerialBridge extends EventEmitter {
     return usage;
   }
 
+  async getGroup5Data() {
+    if (!this.device) {
+      throw new Error('Bridge not connected');
+    }
+
+    const group5Data = await this.device.getGroup5Data();
+    if (group5Data && typeof group5Data === 'object') {
+      const mapped = this._handleStatus(group5Data);
+      this.emit('group5Data', { ...group5Data, ...mapped });
+    }
+    return group5Data;
+  }
+
   async set(datapointId, value) {
     if (!this.device) {
       throw new Error('Bridge not connected');
@@ -295,6 +308,19 @@ class MideaSerialBridge extends EventEmitter {
     if (outdoorTemperature !== undefined) {
       mapped.outdoorTemperature = outdoorTemperature;
     }
+
+    const indoorHumidity = this._coerceFiniteNumber(status.humidity ?? status.indoorHumidity);
+    if (indoorHumidity !== undefined) {
+      mapped.indoorHumidity = indoorHumidity;
+    }
+
+    const outdoorFanSpeed = this._coerceFiniteNumber(status.outdoorFanSpeed);
+    if (outdoorFanSpeed !== undefined) {
+      mapped.outdoorFanSpeed = outdoorFanSpeed;
+    }
+
+    assignBoolean('defrost', 'defrostActive');
+    assignBoolean('defrostActive');
 
     if (status.fanSpeed !== undefined) {
       const normalized = this._normalizeFanSpeedFromStatus(status.fanSpeed);

--- a/lib/node-mideahvac/lib/ac.js
+++ b/lib/node-mideahvac/lib/ac.js
@@ -14,6 +14,21 @@ logger.add(new logger.transports.Console({
   level: 'none'
 }));
 
+function createGroupDataCommand (group) {
+  const cmd = Buffer.alloc(20, 0x00);
+  cmd[0] = 0x41;
+  cmd[1] = 0x21;
+  cmd[2] = 0x01;
+  cmd[3] = 0x40 | (group & 0x0F);
+  return createCommand(cmd, 0x03);
+}
+
+function createLegacyPowerUsageCommand () {
+  return createCommand(Buffer.from([
+    0x41, 0x21, 0x01, 0x44, 0x00, 0x01
+  ]), 0x03);
+}
+
 // module.exports = class extends SK103 {
 module.exports = class extends EventEmitter {
   constructor () {
@@ -120,22 +135,9 @@ module.exports = class extends EventEmitter {
   getPowerUsage (retry = 0) {
     const self = this;
 
-    logger.silly('AC.getPowerUsage}: Entering');
+    logger.silly('AC.getPowerUsage: Entering');
 
-    // let cmd = Buffer.from([
-    //   0x41, 0x21, 0x01, 0x44, 0x00, 0x00,
-    //   0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    //   0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    //   0x00, 0x00, 0x00, 0x04
-    // ]);
-    let cmd = Buffer.from([
-      0x41, 0x21, 0x01, 0x44, 0x00, 0x01
-    ]);
-    // 0x41, 0x21, 0x01, 0x40 + p1, 0x00, 0x01 check status
-    // 0x41, 0x21, 0x01, 0x80 + p1, 0x02, p2, p3, p4, p5 check elec
-    // 0x41, 0x21, 0x01, 0x44, 0x00, 0x01
-
-    cmd = createCommand(cmd, 0x03);
+    const cmd = createGroupDataCommand(4);
 
     return new Promise((resolve, reject) => {
       // Send the command
@@ -147,8 +149,59 @@ module.exports = class extends EventEmitter {
           }
 
           const parsedData = self._parseResponse(response);
+          if (parsedData.powerUsage === undefined) {
+            throw new Error('Group 4 response did not contain power usage');
+          }
 
           // Update in-memory state
+          const updates = self._updateStatus(parsedData);
+
+          if (Object.keys(updates).length) {
+            self.emit('status-update', reporter(updates));
+          }
+
+          resolve(reporter(parsedData));
+        })
+        .catch(error => {
+          logger.debug(`AC.getPowerUsage: 20-byte group 4 request failed (${error.message}); trying legacy 6-byte request`);
+
+          self._request(createLegacyPowerUsageCommand(), 'getPowerUsageLegacy', retry)
+            .then(response => {
+              if (response[10] !== 0xC1) {
+                return reject(new Error('Invalid response'));
+              }
+
+              const parsedData = self._parseResponse(response);
+              const updates = self._updateStatus(parsedData);
+
+              if (Object.keys(updates).length) {
+                self.emit('status-update', reporter(updates));
+              }
+
+              resolve(reporter(parsedData));
+            })
+            .catch(legacyError => {
+              reject(legacyError);
+            });
+        });
+    });
+  }
+
+  getGroup5Data (retry = 0) {
+    const self = this;
+
+    logger.silly('AC.getGroup5Data: Entering');
+
+    const cmd = createGroupDataCommand(5);
+
+    return new Promise((resolve, reject) => {
+      self._request(cmd, 'getGroup5Data', retry)
+        .then(response => {
+          if (response[10] !== 0xC1) {
+            return reject(new Error('Invalid response'));
+          }
+
+          const parsedData = self._parseResponse(response);
           const updates = self._updateStatus(parsedData);
 
           if (Object.keys(updates).length) {

--- a/lib/node-mideahvac/lib/parsers/C1.js
+++ b/lib/node-mideahvac/lib/parsers/C1.js
@@ -5,15 +5,15 @@ const { addParserDebug } = require('./raw');
 
 // Add a transport as fall back when no parent logger has been initialized
 // to prevent the error: "Attempt to write logs with no transports"
-logger.add(new logger.transports.Console({
-  level: 'none'
-}));
+logger.add(
+  new logger.transports.Console({
+    level: 'none',
+  })
+);
 
-exports.parser = (data, options = {}) => {
-  logger.debug(`C1.parser: Entering with ${data.toString('hex')}`);
-
+function parsePowerUsage(data) {
   if (data.length < 19) {
-    logger.error(`C1.parser: Invalid length of message (${data.length})`);
+    logger.error(`C1.parser: Invalid length of group 4 message (${data.length})`);
     return {};
   }
 
@@ -23,10 +23,63 @@ exports.parser = (data, options = {}) => {
   let n = 0;
   let m = 1;
   for (let i = 0; i < 3; i++) {
-    n += (data[18 - i] & 0x0F) * m;
-    n += ((data[18 - i] >> 4) & 0x0F) * m * 10;
+    n += (data[18 - i] & 0x0f) * m;
+    n += ((data[18 - i] >> 4) & 0x0f) * m * 10;
     m *= 100;
   }
 
-  return addParserDebug({ powerUsage: n / 10000 }, data, options);
+  return { powerUsage: n / 10000 };
+}
+
+function parseGroup5(data) {
+  const status = {};
+
+  if (data.length > 4) {
+    const humidity = data[4];
+    status.humidity = humidity === 0 ? null : humidity;
+    status.indoorHumidity = humidity === 0 ? null : humidity;
+  }
+
+  if (data.length > 8) {
+    status.outdoorFanSpeed = data[8] * 8;
+  }
+
+  if (data.length > 10) {
+    status.defrost = Boolean(data[10]);
+    status.defrostActive = Boolean(data[10]);
+  }
+
+  return status;
+}
+
+exports.parser = (data, options = {}) => {
+  logger.debug(`C1.parser: Entering with ${data.toString('hex')}`);
+
+  if (data.length < 4) {
+    logger.error(`C1.parser: Invalid length of message (${data.length})`);
+    return addParserDebug({}, data, options);
+  }
+
+  const group = data[3] & 0x0f;
+  let status;
+
+  switch (group) {
+    case 4:
+      status = parsePowerUsage(data);
+      break;
+    case 5:
+      status = parseGroup5(data);
+      break;
+    default:
+      logger.debug(`C1.parser: Unsupported group data response (${group})`);
+      status = {};
+      break;
+  }
+
+  status.group = group;
+
+  return addParserDebug(status, data, {
+    ...options,
+    exposeRawBytes: options.exposeRawBytes || group === 5,
+  });
 };

--- a/main.js
+++ b/main.js
@@ -100,6 +100,10 @@ const POLLING_METHODS = [
     id: 'getPowerUsage',
     defaultInterval: 300,
   },
+  {
+    id: 'getGroup5Data',
+    defaultInterval: 300,
+  },
 ];
 
 const POLLING_METHOD_MAP = new Map(POLLING_METHODS.map((entry) => [entry.id, entry]));
@@ -202,6 +206,12 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
       this.bridge.on('powerUsage', (usage) => {
         this._applyPowerUsage(usage).catch((error) => {
           this.log.debug(`Failed to process power usage update: ${this._formatError(error)}`);
+        });
+      });
+
+      this.bridge.on('group5Data', (group5Data) => {
+        this._applyGroup5Data(group5Data).catch((error) => {
+          this.log.debug(`Failed to process group 5 update: ${this._formatError(error)}`);
         });
       });
 
@@ -625,6 +635,9 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
       case 'getPowerUsage':
         this._pollPowerUsage();
         break;
+      case 'getGroup5Data':
+        this._pollGroup5Data();
+        break;
       default:
         this.log.debug(`No polling handler registered for ${methodId}`);
     }
@@ -994,6 +1007,18 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
     }
   }
 
+  async _pollGroup5Data() {
+    if (!this.bridge || !this.bridge.connected) {
+      return;
+    }
+
+    try {
+      await this.bridge.getGroup5Data();
+    } catch (error) {
+      this.log.warn(`Polling group 5 data failed: ${error.message}`);
+    }
+  }
+
   _extractStatusEntries(status) {
     if (!status || typeof status !== 'object') {
       return null;
@@ -1121,6 +1146,44 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
       });
     } catch (error) {
       this.log.debug(`Failed to update power usage state: ${this._formatError(error)}`);
+    }
+  }
+
+  async _applyGroup5Data(group5Data) {
+    if (!group5Data || typeof group5Data !== 'object') {
+      return;
+    }
+
+    if (this.config && this.config.exposeRawStatus) {
+      const rawEntries = this._extractStatusEntries(group5Data);
+      if (rawEntries && rawEntries.length > 0) {
+        await this._applyRawStatus(rawEntries);
+      }
+    }
+
+    const mapped = {
+      indoorHumidity: group5Data.indoorHumidity,
+      outdoorFanSpeed: group5Data.outdoorFanSpeed,
+      defrostActive: group5Data.defrostActive,
+    };
+
+    for (const [datapointId, value] of Object.entries(mapped)) {
+      if (!this.datapointById.has(datapointId) || value === undefined) {
+        continue;
+      }
+
+      const datapoint = this.datapointById.get(datapointId);
+      const normalized = this._normalizeReadValue(datapoint, value);
+      try {
+        await this.setStateAsync(`${datapoint.channel}.${datapoint.id}`, {
+          val: normalized,
+          ack: true,
+        });
+      } catch (error) {
+        this.log.debug(
+          `Failed to update group 5 state ${datapointId}: ${this._formatError(error)}`
+        );
+      }
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iobroker.midea-serialbridge",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iobroker.midea-serialbridge",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "@iobroker/adapter-core": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.midea-serialbridge",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "ioBroker adapter for controlling Midea climate devices via serial bridge",
   "author": {
     "name": "dosordie"
@@ -39,8 +39,9 @@
   "scripts": {
     "lint": "eslint .",
     "format": "prettier --write \"**/*.{js,json,md}\"",
-    "test": "npm run test:raw-parser-helper && npm run lint",
-    "test:raw-parser-helper": "node test/raw-parser-helper.test.js"
+    "test": "npm run test:raw-parser-helper && npm run test:c1-parser && npm run lint",
+    "test:raw-parser-helper": "node test/raw-parser-helper.test.js",
+    "test:c1-parser": "node test/c1-parser.test.js"
   },
   "files": [
     "admin/",

--- a/test/c1-parser.test.js
+++ b/test/c1-parser.test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const assert = require('assert');
+const { parser } = require('../lib/node-mideahvac/lib/parsers/C1');
+
+const group4 = Buffer.alloc(20, 0x00);
+group4[0] = 0xc1;
+group4[3] = 0x44;
+group4[16] = 0x01;
+group4[17] = 0x23;
+group4[18] = 0x45;
+assert.deepStrictEqual(parser(group4), { powerUsage: 1.2345, group: 4 });
+
+const group5 = Buffer.alloc(20, 0x00);
+group5[0] = 0xc1;
+group5[3] = 0x45;
+group5[4] = 55;
+group5[8] = 12;
+group5[10] = 1;
+assert.deepStrictEqual(
+  {
+    humidity: parser(group5).humidity,
+    indoorHumidity: parser(group5).indoorHumidity,
+    outdoorFanSpeed: parser(group5).outdoorFanSpeed,
+    defrost: parser(group5).defrost,
+    defrostActive: parser(group5).defrostActive,
+    group: parser(group5).group,
+  },
+  {
+    humidity: 55,
+    indoorHumidity: 55,
+    outdoorFanSpeed: 96,
+    defrost: true,
+    defrostActive: true,
+    group: 5,
+  }
+);
+
+const group5ZeroHumidity = Buffer.from(group5);
+group5ZeroHumidity[4] = 0;
+assert.strictEqual(parser(group5ZeroHumidity).humidity, null);
+assert.strictEqual(parser(group5ZeroHumidity).indoorHumidity, null);
+
+const shortGroup5 = Buffer.from([0xc1, 0x00, 0x00, 0x45, 44]);
+assert.strictEqual(parser(shortGroup5).humidity, 44);
+assert.strictEqual(parser(shortGroup5).indoorHumidity, 44);
+assert.strictEqual(parser(shortGroup5).group, 5);
+
+const debug = parser(group5, { exposeRawBytes: true, frame: Buffer.from([0xaa, 0xbb]) });
+assert.strictEqual(debug.rawFrameHex, 'aabb');
+assert.strictEqual(debug.payloadHex, group5.toString('hex'));
+assert.strictEqual(debug.rawBytes['04'].u8, 55);
+
+console.log('C1 parser tests passed');


### PR DESCRIPTION
### Motivation
- Support Midea AC Group-5 C1 Group-Data responses (humidity / outdoor fan / defrost) in addition to existing C0/C1/B5 handling.
- Provide a polling request analogous to `msmart-ng` so Group-5 data can be collected regularly and exposed as ioBroker datapoints.
- Keep existing power/energy (Group-4) handling intact while making the Group-4 request compatible with 20-byte devices and falling back to the legacy 6-byte variant when needed.

### Description
- Add a new polling method `getGroup5Data` and schedule/handler in `main.js` including `_pollGroup5Data`, event wiring and `_applyGroup5Data` state mapping.
- Extend bridge API in `lib/midea-serial-bridge.js` with `getGroup5Data()` and map `status.humidity`, `status.outdoorFanSpeed`, and `status.defrost` into adapter states (`indoorHumidity`, `outdoorFanSpeed`, `defrostActive`).
- Implement 20-byte group-data command generation and legacy fallback in `lib/node-mideahvac/lib/ac.js` via `createGroupDataCommand(group)` and `createLegacyPowerUsageCommand()`, use Group 4 for power usage request with a fallback to the legacy 6-byte request.
- Enhance the C1 parser `lib/node-mideahvac/lib/parsers/C1.js` to distinguish `group = frame[3] & 0x0F`: keep Group-4 power/energy extraction, add Group-5 parsing for `humidity` (treat 0 as null), `outdoorFanSpeed = payload[8] * 8`, `defrost/defrostActive = Boolean(payload[10])`, and preserve raw debug fields (`rawFrameHex`, `payloadHex`, `rawBytes`, and analog candidates) robustly for analysis and statusRaw exposure.
- Add ioBroker datapoints in `lib/datapoints.js` for `sensors.indoorHumidity`, `sensors.outdoorFanSpeed`, and `sensors.defrostActive` and add admin UI option `getGroup5Data` in `admin/jsonConfig.json` and i18n translations.
- Bump package versions to `0.0.3` (`package.json`, `io-package.json`, `package-lock.json`) and add unit tests for C1 parser in `test/c1-parser.test.js`.

### Testing
- Ran the repository test script `npm test`, which runs `node test/raw-parser-helper.test.js`, `node test/c1-parser.test.js` and `eslint .`; all tests completed successfully.
- Added C1 parser unit tests (`test/c1-parser.test.js`) validating Group-4 power parsing, Group-5 humidity/outdoor fan/defrost parsing, zero-humidity -> `null` handling, short Group-5 frames, and raw debug exposure; tests passed under `npm test`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a269060fa8c832584842ab1351f90c6)