### PR TITLE
Polling-Konfiguration: Normalisierung, Migration und Admin-Defaults

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -207,8 +207,8 @@
           },
           "default": false,
           "help": {
-            "en": "Allow overriding the default interval for the commands listed below.",
-            "de": "Ermöglicht es, das Standardintervall für die unten aufgeführten Befehle zu überschreiben."
+            "en": "Legacy compatibility switch only; configured commands below are always used when present.",
+            "de": "Nur noch Kompatibilitätsschalter; die unten konfigurierten Befehle werden immer verwendet, wenn sie vorhanden sind."
           },
           "xs": 12,
           "sm": 6,
@@ -341,6 +341,28 @@
               "min": 5,
               "max": 3600,
               "unit": "s"
+            }
+          ],
+          "default": [
+            {
+              "id": "getStatus",
+              "enabled": true,
+              "interval": 60
+            },
+            {
+              "id": "getCapabilities",
+              "enabled": false,
+              "interval": 3600
+            },
+            {
+              "id": "getPowerUsage",
+              "enabled": false,
+              "interval": 300
+            },
+            {
+              "id": "getGroup5Data",
+              "enabled": false,
+              "interval": 300
             }
           ]
         }

--- a/io-package.json
+++ b/io-package.json
@@ -106,7 +106,28 @@
     "fanSpeedAsNumber": false,
     "swingModeAsNumber": false,
     "customPolling": false,
-    "pollingRequests": []
+    "pollingRequests": [
+      {
+        "id": "getStatus",
+        "enabled": true,
+        "interval": 60
+      },
+      {
+        "id": "getCapabilities",
+        "enabled": false,
+        "interval": 3600
+      },
+      {
+        "id": "getPowerUsage",
+        "enabled": false,
+        "interval": 300
+      },
+      {
+        "id": "getGroup5Data",
+        "enabled": false,
+        "interval": 300
+      }
+    ]
   },
   "objects": [],
   "instanceObjects": []

--- a/lib/polling-config.js
+++ b/lib/polling-config.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const POLLING_METHODS = [
+  {
+    id: 'getStatus',
+    defaultEnabled: true,
+    defaultInterval: 60,
+  },
+  {
+    id: 'getCapabilities',
+    defaultEnabled: false,
+    defaultInterval: 3600,
+  },
+  {
+    id: 'getPowerUsage',
+    defaultEnabled: false,
+    defaultInterval: 300,
+  },
+  {
+    id: 'getGroup5Data',
+    defaultEnabled: false,
+    defaultInterval: 300,
+  },
+];
+
+const POLLING_METHOD_MAP = new Map(POLLING_METHODS.map((entry) => [entry.id, entry]));
+
+function normalizeBooleanValue(value) {
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) {
+      return false;
+    }
+    if (normalized === 'true' || normalized === '1') {
+      return true;
+    }
+    if (normalized === 'false' || normalized === '0') {
+      return false;
+    }
+  }
+
+  return value === true || value === 1;
+}
+
+function normalizePollingEnabled(value, fallback) {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (value === 0 || value === 1 || typeof value === 'string') {
+    return normalizeBooleanValue(value);
+  }
+  return fallback;
+}
+
+function normalizePollingInterval(value, fallback) {
+  const numericValue = Number(value);
+  if (!Number.isFinite(numericValue)) {
+    return fallback;
+  }
+
+  return Math.min(Math.max(Math.round(numericValue), 5), 3600);
+}
+
+function describePollingEntries(entries) {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return 'none';
+  }
+
+  return entries
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') {
+        return 'invalid';
+      }
+      return `${entry.id || 'missing-id'}=${entry.enabled}/${entry.interval}s`;
+    })
+    .join(', ');
+}
+
+function normalizePollingRequests(config = {}) {
+  const topLevelRequests = Array.isArray(config.pollingRequests) ? config.pollingRequests : null;
+  const legacyRequests =
+    config.polling && typeof config.polling === 'object' && Array.isArray(config.polling.requests)
+      ? config.polling.requests
+      : null;
+  const sourceRequests =
+    topLevelRequests && topLevelRequests.length > 0 ? topLevelRequests : legacyRequests || [];
+  const configuredById = new Map();
+
+  for (const entry of sourceRequests) {
+    if (!entry || typeof entry !== 'object' || !POLLING_METHOD_MAP.has(entry.id)) {
+      continue;
+    }
+    if (configuredById.has(entry.id)) {
+      continue;
+    }
+
+    const method = POLLING_METHOD_MAP.get(entry.id);
+    configuredById.set(entry.id, {
+      id: entry.id,
+      enabled: normalizePollingEnabled(entry.enabled, method.defaultEnabled),
+      interval: normalizePollingInterval(entry.interval, method.defaultInterval),
+    });
+  }
+
+  return POLLING_METHODS.map((method) => {
+    const configuredEntry = configuredById.get(method.id);
+    return configuredEntry
+      ? { ...configuredEntry }
+      : {
+          id: method.id,
+          enabled: method.defaultEnabled,
+          interval: method.defaultInterval,
+        };
+  });
+}
+
+module.exports = {
+  POLLING_METHODS,
+  POLLING_METHOD_MAP,
+  describePollingEntries,
+  normalizeBooleanValue,
+  normalizePollingRequests,
+};

--- a/main.js
+++ b/main.js
@@ -5,6 +5,12 @@ const { isDeepStrictEqual } = require('node:util');
 const { MideaSerialBridge } = require('./lib/midea-serial-bridge');
 const { DATA_POINTS } = require('./lib/datapoints');
 const {
+  POLLING_METHOD_MAP,
+  describePollingEntries,
+  normalizeBooleanValue,
+  normalizePollingRequests,
+} = require('./lib/polling-config');
+const {
   MODE_ALIASES,
   MODE_NAME_TO_VALUE,
   MODE_NAME_TO_LEGACY_VALUE,
@@ -19,23 +25,6 @@ const {
   normalizeString,
 } = require('./lib/value-mappings');
 const { EXIT_CODES } = utils;
-
-function normalizeBooleanValue(value) {
-  if (typeof value === 'string') {
-    const normalized = value.trim().toLowerCase();
-    if (!normalized) {
-      return false;
-    }
-    if (normalized === 'true' || normalized === '1') {
-      return true;
-    }
-    if (normalized === 'false' || normalized === '0') {
-      return false;
-    }
-  }
-
-  return value === true || value === 1;
-}
 
 function cloneRecursively(value, seen) {
   if (value === null || typeof value !== 'object') {
@@ -87,27 +76,6 @@ function cloneDatapointDefinition(datapoint) {
   return clone;
 }
 
-const POLLING_METHODS = [
-  {
-    id: 'getStatus',
-    defaultInterval: 60,
-  },
-  {
-    id: 'getCapabilities',
-    defaultInterval: 3600,
-  },
-  {
-    id: 'getPowerUsage',
-    defaultInterval: 300,
-  },
-  {
-    id: 'getGroup5Data',
-    defaultInterval: 300,
-  },
-];
-
-const POLLING_METHOD_MAP = new Map(POLLING_METHODS.map((entry) => [entry.id, entry]));
-
 class MideaSerialBridgeAdapter extends utils.Adapter {
   constructor(options = {}) {
     super({
@@ -149,7 +117,11 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
     try {
       await this.setStateAsync('info.connection', false, true);
 
+      this.log.debug(`Polling config found: ${this._describeRawPollingConfig()}`);
       const normalizationResult = this._normalizeConfig();
+      this.log.debug(
+        `Polling config normalized: ${describePollingEntries(this.config.pollingRequests)}`
+      );
       if (normalizationResult.changed) {
         await this._persistNormalizedConfig(normalizationResult.normalizedConfig);
       }
@@ -544,16 +516,22 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
 
   _startPolling() {
     this._clearPolling();
-    const pollingConfig = this._buildPollingConfig().filter((config) => config.enabled);
-    if (pollingConfig.length === 0) {
-      this.log.debug('No polling requests enabled; skipping scheduled commands');
-      return;
-    }
+    const pollingConfig = this._buildPollingConfig();
+    const activeConfig = pollingConfig.filter((config) => config.enabled);
+    this.log.debug(
+      `Polling requests active: ${
+        activeConfig.length > 0 ? activeConfig.map((config) => config.id).join(', ') : 'none'
+      }`
+    );
 
     for (const config of pollingConfig) {
-      const method = POLLING_METHOD_MAP.get(config.id);
-      if (!method) {
+      if (!POLLING_METHOD_MAP.has(config.id)) {
         this.log.debug(`Ignoring unknown polling request ${config.id}`);
+        continue;
+      }
+
+      if (!config.enabled) {
+        this.log.debug(`Polling ${config.id} disabled`);
         continue;
       }
 
@@ -563,6 +541,10 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
       const timer = setInterval(handler, intervalMs);
       this.pollTimers.set(config.id, timer);
       handler();
+    }
+
+    if (activeConfig.length === 0) {
+      this.log.debug('No polling requests enabled; skipping scheduled commands');
     }
   }
 
@@ -644,28 +626,22 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
   }
 
   _buildPollingConfig() {
-    const defaultInterval = Number(this.config.pollingInterval) || 60;
-    const entries = this._getPollingEntries();
-    const map = new Map();
-    for (const entry of entries) {
-      if (!entry || !entry.id) {
-        continue;
-      }
-      map.set(entry.id, {
-        enabled: entry.enabled !== false,
-        interval: Number(entry.interval) || defaultInterval,
-      });
-    }
+    return normalizePollingRequests(this.config || {});
+  }
 
-    return POLLING_METHODS.map((method) => {
-      const entry = map.get(method.id);
-      const fallbackInterval = method.id === 'getStatus' ? defaultInterval : method.defaultInterval;
-      return {
-        id: method.id,
-        enabled: entry ? entry.enabled : method.id === 'getStatus',
-        interval: entry ? entry.interval : fallbackInterval,
-      };
-    });
+  _describeRawPollingConfig() {
+    if (Array.isArray(this.config && this.config.pollingRequests)) {
+      return `native.pollingRequests (${describePollingEntries(this.config.pollingRequests)})`;
+    }
+    if (
+      this.config &&
+      this.config.polling &&
+      typeof this.config.polling === 'object' &&
+      Array.isArray(this.config.polling.requests)
+    ) {
+      return `native.polling.requests (${describePollingEntries(this.config.polling.requests)})`;
+    }
+    return 'none';
   }
 
   _normalizeConfig() {
@@ -825,17 +801,9 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
       changed = true;
     }
 
-    const pollingIsObject = this.config.polling && typeof this.config.polling === 'object';
-    const existingRequests =
-      pollingIsObject && Array.isArray(this.config.polling.requests)
-        ? this.config.polling.requests
-        : null;
-
-    if (!existingRequests && Array.isArray(this.config.pollingRequests)) {
-      this.config.polling = {
-        ...(pollingIsObject ? this.config.polling : {}),
-        requests: this.config.pollingRequests,
-      };
+    const normalizedPollingRequests = normalizePollingRequests(this.config);
+    if (!isDeepStrictEqual(this.config.pollingRequests, normalizedPollingRequests)) {
+      this.config.pollingRequests = normalizedPollingRequests;
       changed = true;
     }
 
@@ -848,16 +816,20 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
       changed = true;
     }
 
+    if (typeof this.config.customPolling !== 'boolean') {
+      this.config.customPolling = false;
+      changed = true;
+    }
+
     if (
       this.config.polling &&
-      Array.isArray(this.config.polling.requests) &&
-      !Array.isArray(this.config.pollingRequests)
+      typeof this.config.polling === 'object' &&
+      Object.prototype.hasOwnProperty.call(this.config.polling, 'requests')
     ) {
-      this.config.pollingRequests = this.config.polling.requests.map((entry) => ({
-        id: entry.id,
-        enabled: entry.enabled !== false,
-        interval: Number(entry.interval) || Number(this.config.pollingInterval) || 60,
-      }));
+      delete this.config.polling.requests;
+      if (Object.keys(this.config.polling).length === 0) {
+        delete this.config.polling;
+      }
       changed = true;
     }
 
@@ -1000,6 +972,8 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
       return;
     }
 
+    this.log.debug('Polling power usage now');
+
     try {
       await this.bridge.getPowerUsage();
     } catch (error) {
@@ -1011,6 +985,8 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
     if (!this.bridge || !this.bridge.connected) {
       return;
     }
+
+    this.log.debug('Polling group 5 data now');
 
     try {
       await this.bridge.getGroup5Data();
@@ -1275,16 +1251,6 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
     });
 
     this._knownCapabilityStates.add(key);
-  }
-
-  _getPollingEntries() {
-    if (this.config.polling && Array.isArray(this.config.polling.requests)) {
-      return this.config.polling.requests;
-    }
-    if (Array.isArray(this.config.pollingRequests)) {
-      return this.config.pollingRequests;
-    }
-    return [];
   }
 
   _normalizeWriteValue(datapoint, value) {
@@ -1560,7 +1526,9 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
 }
 
 if (module.parent) {
-  module.exports = (options) => new MideaSerialBridgeAdapter(options);
+  const createAdapter = (options) => new MideaSerialBridgeAdapter(options);
+  createAdapter.MideaSerialBridgeAdapter = MideaSerialBridgeAdapter;
+  module.exports = createAdapter;
 } else {
   new MideaSerialBridgeAdapter();
 }

--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
   "scripts": {
     "lint": "eslint .",
     "format": "prettier --write \"**/*.{js,json,md}\"",
-    "test": "npm run test:raw-parser-helper && npm run test:c1-parser && npm run lint",
+    "test": "npm run test:raw-parser-helper && npm run test:c1-parser && npm run test:polling-config && npm run lint",
     "test:raw-parser-helper": "node test/raw-parser-helper.test.js",
-    "test:c1-parser": "node test/c1-parser.test.js"
+    "test:c1-parser": "node test/c1-parser.test.js",
+    "test:polling-config": "node test/polling-config.test.js"
   },
   "files": [
     "admin/",

--- a/test/polling-config.test.js
+++ b/test/polling-config.test.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const assert = require('assert');
+const { normalizePollingRequests } = require('../lib/polling-config');
+
+const DEFAULT_REQUESTS = [
+  { id: 'getStatus', enabled: true, interval: 60 },
+  { id: 'getCapabilities', enabled: false, interval: 3600 },
+  { id: 'getPowerUsage', enabled: false, interval: 300 },
+  { id: 'getGroup5Data', enabled: false, interval: 300 },
+];
+
+assert.deepStrictEqual(normalizePollingRequests({}), DEFAULT_REQUESTS);
+
+assert.deepStrictEqual(
+  normalizePollingRequests({
+    polling: {
+      requests: [
+        { id: 'getStatus', enabled: true, interval: 30 },
+        { id: 'getPowerUsage', enabled: true, interval: 45 },
+      ],
+    },
+  }),
+  [
+    { id: 'getStatus', enabled: true, interval: 30 },
+    { id: 'getCapabilities', enabled: false, interval: 3600 },
+    { id: 'getPowerUsage', enabled: true, interval: 45 },
+    { id: 'getGroup5Data', enabled: false, interval: 300 },
+  ]
+);
+
+assert.deepStrictEqual(
+  normalizePollingRequests({
+    pollingRequests: [
+      { id: 'getStatus', enabled: false, interval: 120 },
+      { id: 'getCapabilities', enabled: true, interval: 600 },
+    ],
+  }),
+  [
+    { id: 'getStatus', enabled: false, interval: 120 },
+    { id: 'getCapabilities', enabled: true, interval: 600 },
+    { id: 'getPowerUsage', enabled: false, interval: 300 },
+    { id: 'getGroup5Data', enabled: false, interval: 300 },
+  ]
+);
+
+assert.deepStrictEqual(
+  normalizePollingRequests({
+    pollingRequests: [
+      { id: 'getPowerUsage', enabled: true, interval: 30 },
+      { id: 'getPowerUsage', enabled: false, interval: 999 },
+    ],
+  }).find((entry) => entry.id === 'getPowerUsage'),
+  { id: 'getPowerUsage', enabled: true, interval: 30 }
+);
+
+assert.deepStrictEqual(
+  normalizePollingRequests({
+    pollingRequests: [
+      { id: 'unknownMethod', enabled: true, interval: 10 },
+      { id: 'getGroup5Data', enabled: true, interval: 60 },
+    ],
+  }),
+  [
+    { id: 'getStatus', enabled: true, interval: 60 },
+    { id: 'getCapabilities', enabled: false, interval: 3600 },
+    { id: 'getPowerUsage', enabled: false, interval: 300 },
+    { id: 'getGroup5Data', enabled: true, interval: 60 },
+  ]
+);
+
+assert.deepStrictEqual(
+  normalizePollingRequests({
+    pollingRequests: [{ id: 'getStatus', enabled: true, interval: 60 }],
+  }).map((entry) => entry.id),
+  ['getStatus', 'getCapabilities', 'getPowerUsage', 'getGroup5Data']
+);
+
+assert.deepStrictEqual(
+  normalizePollingRequests({
+    pollingRequests: [{ id: 'getPowerUsage', enabled: true, interval: 30 }],
+  }).find((entry) => entry.id === 'getPowerUsage'),
+  { id: 'getPowerUsage', enabled: true, interval: 30 }
+);
+
+assert.deepStrictEqual(
+  normalizePollingRequests({
+    pollingRequests: [{ id: 'getGroup5Data', enabled: false, interval: 30 }],
+  }).find((entry) => entry.id === 'getGroup5Data'),
+  { id: 'getGroup5Data', enabled: false, interval: 30 }
+);
+
+assert.deepStrictEqual(
+  normalizePollingRequests({
+    pollingRequests: [{ id: 'getPowerUsage', enabled: 'true', interval: 'not-a-number' }],
+  }).find((entry) => entry.id === 'getPowerUsage'),
+  { id: 'getPowerUsage', enabled: true, interval: 300 }
+);
+
+console.log('polling config normalization tests passed');


### PR DESCRIPTION
### Motivation
- Die Adapter-Instanz speichert Polling-Einstellungen inkonsistent (`polling.requests` vs. `pollingRequests`), sodass nach Neustart nur `getStatus` geplant wurde und zusätzliche Befehle wie `getPowerUsage`/`getGroup5Data` nicht ausgeführt wurden.
- Ziel war eine robuste, rückwärtskompatible Normalisierung und persistente Speicherung als ein eindeutiges Array `native.pollingRequests` ohne bereits vom Nutzer gesetzte Werte zu überschreiben.

### Description
- Zentralisiert Normalisierung und Validierung in `lib/polling-config.js` mit `normalizePollingRequests`, `describePollingEntries` und Hilfsfunktionen, die alte Strukturen migrieren, ungültige IDs ignorieren, Duplikate entfernen und fehlende Methoden mit Defaults ergänzen; `POLLING_METHODS`-Definitionen enthalten `defaultEnabled`/`defaultInterval`.
- `main.js` nutzt `normalizePollingRequests` in `_buildPollingConfig()` und `_normalizeConfig()` und schreibt nach Normalisierung immer ein vollständiges `this.config.pollingRequests`; alte `polling.requests`-Einträge werden nach Migration entfernt und `customPolling` bleibt ein Legacy-Flag, das die neuen Einträge nicht blockiert.
- Start- und Scheduler-Logging verbessert: beim Start wird gezeigt, welche Roh-Konfiguration gefunden wurde und wie sie normalisiert wurde (`Polling config found`, `Polling config normalized`), sowie welche Requests aktiv, deaktiviert oder ignoriert sind; `_pollPowerUsage()` und `_pollGroup5Data()` erhalten temporäre Debug-Zeilen (`Polling power usage now`, `Polling group 5 data now`).
- Admin-/Packaging-Änderungen: `admin/jsonConfig.json` bekommt einen sinnvollen `default`-Block für die `pollingRequests`-Tabelle und Hilfetext von `customPolling` auf Legacy-Kompatibilität angepasst; `io-package.json` enthält dieselben Native-Defaults; Unit-Test `test/polling-config.test.js` hinzugefügt und `package.json`-Testscripte erweitert.

### Testing
- Ausführung von `npm run test` (bestehend aus `test/raw-parser-helper`, `test/c1-parser`, `test:polling-config` und `eslint`) wurde lokal ausgeführt und alle Tests liefen erfolgreich durch.
- Speziell wurde `test/polling-config.test.js` ausgeführt und die Normalisierungsfälle (leere Config, legacy `polling.requests`, vorhandene `pollingRequests`, doppelte/ungültige IDs, Ergänzung fehlender Methoden, Erhalt von Nutzerwerten) bestanden.
- Linting (`eslint`) wurde im Testlauf ausgeführt und es traten keine Blocker-Fehler auf.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2699997e94832581d58f7a0241a6e6)