### PR TITLE
Add C1 group 4 total energy state

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The following datapoints are available out of the box:
 | `targetTemperature` | Desired room temperature | ✓ | ✓ |
 | `indoorTemperature` | Current indoor temperature | ✓ | ✗ |
 | `outdoorTemperature` | Current outdoor temperature | ✓ | ✗ |
+| `totalEnergy` | Internal total energy counter from C1 group 4 (kWh) | ✓ | ✗ |
 | `fanSpeed` | Fan speed (auto, low, medium, high) | ✓ | ✓ |
 | `swingMode` | Swing mode (off, vertical, horizontal, both) | ✓ | ✓ |
 | `ecoMode` | Eco mode | ✓ | ✓ |

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "name": "midea-serialbridge",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "titleLang": {
       "en": "Midea Serial Bridge",
       "de": "Midea Serial Bridge",

--- a/lib/datapoints.js
+++ b/lib/datapoints.js
@@ -186,6 +186,15 @@ const DATA_POINTS = [
     readOnly: true,
   },
   {
+    id: 'totalEnergy',
+    channel: 'sensors',
+    name: 'Total energy',
+    role: 'value.energy',
+    type: 'number',
+    unit: 'kWh',
+    readOnly: true,
+  },
+  {
     id: 'indoorHumidity',
     channel: 'sensors',
     name: 'Indoor humidity',

--- a/lib/node-mideahvac/README.md
+++ b/lib/node-mideahvac/README.md
@@ -157,6 +157,7 @@ The following methods are provided:
 | Property | Type | Description |
 | --- | --- | --- |
 | powerUsage | number | Power usage in kWh |
+| totalEnergy | number | Internal total energy counter in kWh |
 
 * `getStatus(retry)`, this method requests the current status of the unit (0x41 command). The promise resolves to a JSON object containing the property values when successful. The following properties are reported:
 

--- a/lib/node-mideahvac/lib/parsers/C1.js
+++ b/lib/node-mideahvac/lib/parsers/C1.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const logger = require('winston');
-const { addParserDebug } = require('./raw');
+const { addParserDebug, bcdByteToNumber } = require('./raw');
 
 // Add a transport as fall back when no parent logger has been initialized
 // to prevent the error: "Attempt to write logs with no transports"
@@ -11,24 +11,53 @@ logger.add(
   })
 );
 
+function decodeBcdNumber(data, start, length) {
+  if (data.length < start + length) {
+    return null;
+  }
+
+  let value = 0;
+  for (let i = 0; i < length; i++) {
+    const decodedByte = bcdByteToNumber(data[start + i]);
+    if (decodedByte === null) {
+      return null;
+    }
+
+    value = value * 100 + decodedByte;
+  }
+
+  return value;
+}
+
 function parsePowerUsage(data) {
   if (data.length < 19) {
     logger.error(`C1.parser: Invalid length of group 4 message (${data.length})`);
     return {};
   }
 
+  const status = {};
+
+  // Bytes 4-7 contain the BCD representation of the internal total energy
+  // counter in kWh with two decimal places.
+  const totalEnergy = decodeBcdNumber(data, 4, 4);
+  if (totalEnergy === null) {
+    logger.debug('C1.parser: Could not decode group 4 totalEnergy from bytes 4-7');
+  } else {
+    status.totalEnergy = totalEnergy / 100;
+    logger.debug(`C1.parser: Decoded group 4 totalEnergy: ${status.totalEnergy} kWh`);
+  }
+
   // Byte 16, 17, and 18 contain the binary coded decimal representation of
   // the current power usage. This is a confirmed analog-like energy value;
   // remaining C1 bytes are exposed via raw/analog debug options for analysis.
-  let n = 0;
-  let m = 1;
-  for (let i = 0; i < 3; i++) {
-    n += (data[18 - i] & 0x0f) * m;
-    n += ((data[18 - i] >> 4) & 0x0f) * m * 10;
-    m *= 100;
+  const powerUsage = decodeBcdNumber(data, 16, 3);
+  if (powerUsage === null) {
+    logger.debug('C1.parser: Could not decode group 4 powerUsage from bytes 16-18');
+  } else {
+    status.powerUsage = powerUsage / 10000;
   }
 
-  return { powerUsage: n / 10000 };
+  return status;
 }
 
 function parseGroup5(data) {

--- a/main.js
+++ b/main.js
@@ -1109,19 +1109,28 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
       }
     }
 
-    if (!this.datapointById.has('powerUsage')) {
-      return;
-    }
+    const mapped = {
+      powerUsage: usage.powerUsage,
+      totalEnergy: usage.totalEnergy,
+    };
 
-    const datapoint = this.datapointById.get('powerUsage');
-    const normalized = this._normalizeReadValue(datapoint, usage.powerUsage);
-    try {
-      await this.setStateAsync(`${datapoint.channel}.${datapoint.id}`, {
-        val: normalized,
-        ack: true,
-      });
-    } catch (error) {
-      this.log.debug(`Failed to update power usage state: ${this._formatError(error)}`);
+    for (const [datapointId, value] of Object.entries(mapped)) {
+      if (!this.datapointById.has(datapointId) || value === undefined) {
+        continue;
+      }
+
+      const datapoint = this.datapointById.get(datapointId);
+      const normalized = this._normalizeReadValue(datapoint, value);
+      try {
+        await this.setStateAsync(`${datapoint.channel}.${datapoint.id}`, {
+          val: normalized,
+          ack: true,
+        });
+      } catch (error) {
+        this.log.debug(
+          `Failed to update power usage state ${datapointId}: ${this._formatError(error)}`
+        );
+      }
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iobroker.midea-serialbridge",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iobroker.midea-serialbridge",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
         "@iobroker/adapter-core": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.midea-serialbridge",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "ioBroker adapter for controlling Midea climate devices via serial bridge",
   "author": {
     "name": "dosordie"

--- a/test/c1-parser.test.js
+++ b/test/c1-parser.test.js
@@ -9,7 +9,13 @@ group4[3] = 0x44;
 group4[16] = 0x01;
 group4[17] = 0x23;
 group4[18] = 0x45;
-assert.deepStrictEqual(parser(group4), { powerUsage: 1.2345, group: 4 });
+assert.deepStrictEqual(parser(group4), { totalEnergy: 0, powerUsage: 1.2345, group: 4 });
+
+const group4TotalEnergy = Buffer.from('c121014400193025000000000000000000000000', 'hex');
+assert.strictEqual(parser(group4TotalEnergy).totalEnergy, 1930.25);
+
+const group4EarlierTotalEnergy = Buffer.from('c121014400193014000000000000000000000000', 'hex');
+assert.strictEqual(parser(group4EarlierTotalEnergy).totalEnergy, 1930.14);
 
 const group5 = Buffer.alloc(20, 0x00);
 group5[0] = 0xc1;


### PR DESCRIPTION
### Motivation

- The C1 / Group-4 payload contains an internal total energy counter that is BCD-encoded and should be exposed as its own ioBroker state so the adapter reports the unit's cumulative energy (kWh).
- Keep existing `powerUsage` handling and all raw-debug outputs unchanged while adding the new datapoint.

### Description

- Decode bytes `payload[4..7]` in the C1 Group-4 parser as a BCD value and interpret it as `totalEnergy = BCD(payload[4..7]) / 100` (kWh) in `lib/node-mideahvac/lib/parsers/C1.js` and log successful decodes at debug level with `Decoded group 4 totalEnergy: … kWh`.
- Preserve `powerUsage` decoding from bytes `16..18`; both `powerUsage` and `totalEnergy` are returned from the parser as available.
- Add a new ioBroker datapoint definition `sensors.totalEnergy` in `lib/datapoints.js` with `id: 'totalEnergy'`, `name: 'Total energy'`, `role: 'value.energy'`, `type: 'number'`, `unit: 'kWh'`, and `readOnly: true`.
- Extend the power-usage application path in `main.js` to write both `usage.powerUsage` and `usage.totalEnergy` to their respective `sensors.*` states when present.
- Add parser unit tests in `test/c1-parser.test.js` for the observed frames (e.g. `c121014400193025000000000000000000000000 -> 1930.25 kWh` and `c121014400193014000000000000000000000000 -> 1930.14 kWh`).
- Update documentation (`README.md`, `lib/node-mideahvac/README.md`) and bump package version to `0.0.4` (`package.json`, `package-lock.json`, `io-package.json`).

### Testing

- Ran `npm run test:c1-parser` and the C1 parser tests passed.
- Ran the full test suite with `npm test` (includes raw parser helper and polling-config tests) and all automated tests completed successfully.
- Linting (`eslint`) ran as part of `npm test` and the final run completed without blocking errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26a5ca1acc83259ddf667909ce83ae)