### PR TITLE
Add safe unknown C1 group diagnosis polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <img src="admin/midea-serialbridge.svg" alt="Logo" width="120"/>
 # ioBroker.midea-serialbridge
 
-
 ## midea-serialbridge adapter for ioBroker
 
 This adapter allows you to control Midea HVAC units locally using the well known serial bridge interface. It is based on the logic of the [node-mideahvac](https://github.com/reneklootwijk/node-mideahvac) project and exposes all relevant datapoints to ioBroker. Cloud functionality has intentionally been left out so that the devices can be operated without an external connection.
@@ -10,39 +9,47 @@ For easier maintenance and to allow local modifications we ship a vendored copy 
 
 ## Features
 
-* Connect to a TCP serial bridge (default port 23)
-* Poll the device for specific datapoints at configurable intervals
-* Write commands from ioBroker states back to the air conditioner
-* Send raw JSON commands to the bridge for advanced control scenarios
-* Automatic reconnects and error handling
-* JSON based configuration UI
-* Optional exposure of all raw status properties as read-only ioBroker states
+- Connect to a TCP serial bridge (default port 23)
+- Poll the device for specific datapoints at configurable intervals
+- Write commands from ioBroker states back to the air conditioner
+- Send raw JSON commands to the bridge for advanced control scenarios
+- Automatic reconnects and error handling
+- JSON based configuration UI
+- Optional exposure of all raw status properties as read-only ioBroker states
 
 ## Prerequisites
 
-* ioBroker host running js-controller 5.0.19 or newer
-* Node.js 18 or newer
-* A working Midea serial bridge that is reachable from the ioBroker host
+- ioBroker host running js-controller 5.0.19 or newer
+- Node.js 18 or newer
+- A working Midea serial bridge that is reachable from the ioBroker host
 
 ## Configuration
 
 Open the adapter configuration in the ioBroker Admin. Enter the IP address (or hostname) and port of your serial bridge on the **Connection** tab. The **Options** tab allows you to disable the audible confirmation beep, enable exposing raw status values and configure polling behaviour. You can enable or disable polling for each datapoint and configure custom intervals. If no custom interval is specified, the global interval is used. Enable the checkbox **Expose raw status datapoints** to automatically create read-only states for every property reported by the device (e.g. timers, lights or diagnostic flags). The additional states are created beneath the `statusRaw.*` channel and contain the raw values as delivered by the unit. If your bridge occasionally becomes unreachable you can enable **Restart adapter on connection errors** and specify the restart interval to automatically recover from prolonged outages without manual interaction.
 
+### Unknown C1 group diagnosis mode
+
+For protocol analysis you can enable **Enable unknown group diagnosis polling** on the **Options** tab. This mode is intentionally read-only: it sends only safe 20-byte C1 query frames in the known `41 21 01 <group> 00 ... 00` schema and does not send control, SetStatus or B0 property-set frames.
+
+Configure **Unknown group IDs** as comma-separated hexadecimal group bytes from `0x40` to `0x4F`, for example `40,41,42,43,46,47,48,49`. The adapter ignores invalid values and duplicates, enforces a minimum interval of 10 seconds, limits the list to 8 groups, and polls the groups sequentially with a small pause so the device is not flooded.
+
+Responses are written only below `statusRaw.unknownGroups.groupXX.*` for analysis and never create normal sensor datapoints. Each response includes `rawFrameHex`, `payloadHex`, `responseId`, `groupByte`, `rawBytes` and `analogCandidates`. Compare `payloadHex`, `rawBytes` and `analogCandidates` while changing real-world conditions (temperatures, compressor load, fan speed, EEV position, defrost/protection state) to identify bytes that move consistently.
+
 The following datapoints are available out of the box:
 
-| State ID | Description | Read | Write |
-| --- | --- | --- | --- |
-| `power` | Turn the unit on or off | ✓ | ✓ |
-| `mode` | Operation mode (auto, cool, heat, dry, fan) | ✓ | ✓ |
-| `targetTemperature` | Desired room temperature | ✓ | ✓ |
-| `indoorTemperature` | Current indoor temperature | ✓ | ✗ |
-| `outdoorTemperature` | Current outdoor temperature | ✓ | ✗ |
-| `totalEnergy` | Internal total energy counter from C1 group 4 (kWh) | ✓ | ✗ |
-| `fanSpeed` | Fan speed (auto, low, medium, high) | ✓ | ✓ |
-| `swingMode` | Swing mode (off, vertical, horizontal, both) | ✓ | ✓ |
-| `ecoMode` | Eco mode | ✓ | ✓ |
-| `turboMode` | Turbo / powerful mode | ✓ | ✓ |
-| `sleepMode` | Sleep mode | ✓ | ✓ |
+| State ID             | Description                                         | Read | Write |
+| -------------------- | --------------------------------------------------- | ---- | ----- |
+| `power`              | Turn the unit on or off                             | ✓    | ✓     |
+| `mode`               | Operation mode (auto, cool, heat, dry, fan)         | ✓    | ✓     |
+| `targetTemperature`  | Desired room temperature                            | ✓    | ✓     |
+| `indoorTemperature`  | Current indoor temperature                          | ✓    | ✗     |
+| `outdoorTemperature` | Current outdoor temperature                         | ✓    | ✗     |
+| `totalEnergy`        | Internal total energy counter from C1 group 4 (kWh) | ✓    | ✗     |
+| `fanSpeed`           | Fan speed (auto, low, medium, high)                 | ✓    | ✓     |
+| `swingMode`          | Swing mode (off, vertical, horizontal, both)        | ✓    | ✓     |
+| `ecoMode`            | Eco mode                                            | ✓    | ✓     |
+| `turboMode`          | Turbo / powerful mode                               | ✓    | ✓     |
+| `sleepMode`          | Sleep mode                                          | ✓    | ✓     |
 
 Whenever you change a writable state in ioBroker the adapter forwards the command to the bridge immediately.
 
@@ -64,20 +71,20 @@ Successful commands are acknowledged automatically and the resulting status upda
 
 ## Known limitations
 
-* Only local serial control is supported. Cloud features (OSK) are explicitly not part of this adapter.
-* The adapter currently supports a single indoor unit per instance.
+- Only local serial control is supported. Cloud features (OSK) are explicitly not part of this adapter.
+- The adapter currently supports a single indoor unit per instance.
 
 ## Changelog
 
 ### 0.0.2
 
-* Align admin JSON config layout sizes with adapter checker requirements.
-* Add required license metadata type information.
-* Remove deprecated metadata and release version 0.0.2.
+- Align admin JSON config layout sizes with adapter checker requirements.
+- Add required license metadata type information.
+- Remove deprecated metadata and release version 0.0.2.
 
 ### 0.0.1
 
-* Initial release of the adapter.
+- Initial release of the adapter.
 
 See [CHANGELOG.md](CHANGELOG.md).
 

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -199,6 +199,61 @@
           "lg": 4,
           "xl": 3
         },
+        "enableUnknownGroupPolling": {
+          "type": "checkbox",
+          "label": {
+            "en": "Enable unknown group diagnosis polling",
+            "de": "Diagnoseabfrage unbekannter Gruppen aktivieren"
+          },
+          "default": false,
+          "help": {
+            "en": "Sends only safe 20-byte C1 query frames (41 21 01 <group> 00 ... 00) for configured group bytes.",
+            "de": "Sendet ausschließlich sichere 20-Byte-C1-Query-Frames (41 21 01 <group> 00 ... 00) für konfigurierte Gruppenbytes."
+          },
+          "xs": 12,
+          "sm": 6,
+          "md": 4,
+          "lg": 4,
+          "xl": 3
+        },
+        "unknownGroupPollingInterval": {
+          "type": "number",
+          "label": {
+            "en": "Unknown group polling interval",
+            "de": "Abfrageintervall unbekannter Gruppen"
+          },
+          "default": 60,
+          "help": {
+            "en": "Interval in seconds for the complete unknown-group cycle. Minimum is 10 seconds.",
+            "de": "Intervall in Sekunden für einen vollständigen Zyklus aller unbekannten Gruppen. Minimum sind 10 Sekunden."
+          },
+          "min": 10,
+          "max": 3600,
+          "unit": "s",
+          "xs": 12,
+          "sm": 6,
+          "md": 4,
+          "lg": 4,
+          "xl": 3
+        },
+        "unknownGroupIds": {
+          "type": "text",
+          "label": {
+            "en": "Unknown group IDs",
+            "de": "Unbekannte Gruppen-IDs"
+          },
+          "default": "",
+          "placeholder": "40,41,42,43,46,47,48,49",
+          "help": {
+            "en": "Comma-separated hex group bytes from 0x40 to 0x4F. At most 8 values are used; duplicates and invalid values are ignored.",
+            "de": "Kommagetrennte Hex-Gruppenbytes von 0x40 bis 0x4F. Maximal 8 Werte werden genutzt; doppelte und ungültige Werte werden ignoriert."
+          },
+          "xs": 12,
+          "sm": 12,
+          "md": 8,
+          "lg": 8,
+          "xl": 6
+        },
         "customPolling": {
           "type": "checkbox",
           "label": {

--- a/io-package.json
+++ b/io-package.json
@@ -42,20 +42,13 @@
       "config": "json"
     },
     "readme": "https://github.com/dosordie/ioBroker.midea-serialbridge/blob/main/README.md",
-    "keywords": [
-      "midea",
-      "hvac",
-      "serial",
-      "climate"
-    ],
+    "keywords": ["midea", "hvac", "serial", "climate"],
     "dependencies": [
       {
         "js-controller": ">=5.0.19"
       }
     ],
-    "authors": [
-      "dosordie <info@dosordie.de>"
-    ],
+    "authors": ["dosordie <info@dosordie.de>"],
     "licenseInformation": {
       "license": "MIT",
       "url": "https://github.com/dosordie/ioBroker.midea-serialbridge/blob/main/LICENSE",
@@ -102,6 +95,9 @@
     "exposeRawStatus": false,
     "exposeRawBytes": false,
     "exposeAnalogCandidates": false,
+    "enableUnknownGroupPolling": false,
+    "unknownGroupPollingInterval": 60,
+    "unknownGroupIds": "",
     "modeAsNumber": false,
     "fanSpeedAsNumber": false,
     "swingModeAsNumber": false,

--- a/lib/midea-serial-bridge.js
+++ b/lib/midea-serial-bridge.js
@@ -146,6 +146,20 @@ class MideaSerialBridge extends EventEmitter {
     return usage;
   }
 
+  async getUnknownGroupData(groupByte) {
+    if (!this.device) {
+      throw new Error('Bridge not connected');
+    }
+
+    // Safe diagnosis mode: delegates only to the 20-byte C1 query helper and
+    // intentionally does not update regular status/cache states.
+    const groupData = await this.device.getUnknownGroupData(groupByte);
+    if (groupData && typeof groupData === 'object') {
+      this.emit('unknownGroupData', groupData);
+    }
+    return groupData;
+  }
+
   async getGroup5Data() {
     if (!this.device) {
       throw new Error('Bridge not connected');

--- a/lib/node-mideahvac/lib/ac.js
+++ b/lib/node-mideahvac/lib/ac.js
@@ -5,33 +5,59 @@ const logger = require('winston');
 
 const { createCommand } = require('./ac_common');
 const { parse } = require('./parsers');
+const { buildAnalogCandidates } = require('./parsers/raw');
 const reporter = require('./reporter');
 const errors = require('./errors');
 
 // Add a transport as fall back when no parent logger has been initialized
 // to prevent the error: "Attempt to write logs with no transports"
-logger.add(new logger.transports.Console({
-  level: 'none'
-}));
+logger.add(
+  new logger.transports.Console({
+    level: 'none',
+  })
+);
 
-function createGroupDataCommand (group) {
+function createGroupDataCommand(group) {
+  return createGroupDataCommandByByte(0x40 | (group & 0x0f));
+}
+
+function createGroupDataCommandByByte(groupByte) {
+  if (!Number.isInteger(groupByte) || groupByte < 0x40 || groupByte > 0x4f) {
+    throw new errors.OutOfRangeError('Group byte must be between 0x40 and 0x4F');
+  }
+
+  // Safe diagnosis mode: this creates only the known 20-byte C1 query frame
+  // 41 21 01 <groupByte> 00 ... 00 and never creates control/set frames.
   const cmd = Buffer.alloc(20, 0x00);
   cmd[0] = 0x41;
   cmd[1] = 0x21;
   cmd[2] = 0x01;
-  cmd[3] = 0x40 | (group & 0x0F);
+  cmd[3] = groupByte;
   return createCommand(cmd, 0x03);
 }
 
-function createLegacyPowerUsageCommand () {
-  return createCommand(Buffer.from([
-    0x41, 0x21, 0x01, 0x44, 0x00, 0x01
-  ]), 0x03);
+function buildRawByteMap(payload) {
+  const rawBytes = {};
+  for (let i = 0; i < payload.length; i++) {
+    const key = i.toString().padStart(2, '0');
+    const value = payload[i];
+    rawBytes[key] = {
+      hex: value.toString(16).padStart(2, '0'),
+      u8: value,
+      s8: value & 0x80 ? value - 0x100 : value,
+      bits: value.toString(2).padStart(8, '0'),
+    };
+  }
+  return rawBytes;
+}
+
+function createLegacyPowerUsageCommand() {
+  return createCommand(Buffer.from([0x41, 0x21, 0x01, 0x44, 0x00, 0x01]), 0x03);
 }
 
 // module.exports = class extends SK103 {
 module.exports = class extends EventEmitter {
-  constructor () {
+  constructor() {
     super();
 
     this._initialized = false;
@@ -47,11 +73,11 @@ module.exports = class extends EventEmitter {
     this.parserOptions = {};
   }
 
-  _parseResponse (response) {
+  _parseResponse(response) {
     return parse(response, this.parserOptions || {});
   }
 
-  _updateStatus (properties) {
+  _updateStatus(properties) {
     const self = this;
     const updates = {};
 
@@ -59,7 +85,9 @@ module.exports = class extends EventEmitter {
 
     for (const property in properties) {
       if (self.status[property] !== properties[property]) {
-        logger.debug(`AC._updateStatus: Update ${property} from ${self.status[property]} to ${properties[property]}`);
+        logger.debug(
+          `AC._updateStatus: Update ${property} from ${self.status[property]} to ${properties[property]}`
+        );
 
         self.status[property] = properties[property];
         updates[property] = properties[property];
@@ -69,22 +97,21 @@ module.exports = class extends EventEmitter {
     return updates;
   }
 
-  getCapabilities (retry = 0) {
+  getCapabilities(retry = 0) {
     const self = this;
 
     logger.silly('AC.getCapabilities: Entering');
 
-    let cmd = Buffer.from([
-      0xB5, 0x01, 0x11
-    ]);
+    let cmd = Buffer.from([0xb5, 0x01, 0x11]);
 
     cmd = createCommand(cmd, 0x03);
 
     return new Promise((resolve, reject) => {
-      self._request(cmd, 'getCapabilities', retry)
-        .then(async response => {
+      self
+        ._request(cmd, 'getCapabilities', retry)
+        .then(async (response) => {
           // Check this is the correct response type
-          if (response[10] !== 0xB5) {
+          if (response[10] !== 0xb5) {
             return reject(new Error('Invalid response'));
           }
 
@@ -94,13 +121,16 @@ module.exports = class extends EventEmitter {
           self._capabilitiesRaw = parsedData;
 
           while (parsedData.more) {
-            logger.debug(`AC.getCapabilities: There are more capabilities to be retrieved (${parsedData.more})`);
+            logger.debug(
+              `AC.getCapabilities: There are more capabilities to be retrieved (${parsedData.more})`
+            );
 
-            response = await this._getMoreCapabilities(parsedData.more)
-              .catch(error => {
-                logger.error(`AC.getCapabilities: Failed to retrieve additional capabilities (${error.message})`);
-                return reject(error);
-              });
+            response = await this._getMoreCapabilities(parsedData.more).catch((error) => {
+              logger.error(
+                `AC.getCapabilities: Failed to retrieve additional capabilities (${error.message})`
+              );
+              return reject(error);
+            });
 
             parsedData = self._parseResponse(response);
 
@@ -110,20 +140,18 @@ module.exports = class extends EventEmitter {
 
           resolve(self._capabilities);
         })
-        .catch(error => {
+        .catch((error) => {
           reject(error);
         });
     });
   }
 
-  _getMoreCapabilities (num, retry = 0) {
+  _getMoreCapabilities(num, retry = 0) {
     const self = this;
 
     logger.silly('AC._getMoreCapabilities: Entering');
 
-    let cmd = Buffer.from([
-      0xB5, 0x01, 0x01, 0x00
-    ]);
+    let cmd = Buffer.from([0xb5, 0x01, 0x01, 0x00]);
 
     cmd[cmd.length - 1] = num || 1;
 
@@ -132,7 +160,7 @@ module.exports = class extends EventEmitter {
     return self._request(cmd, 'getMoreCapabilities', retry);
   }
 
-  getPowerUsage (retry = 0) {
+  getPowerUsage(retry = 0) {
     const self = this;
 
     logger.silly('AC.getPowerUsage: Entering');
@@ -141,10 +169,11 @@ module.exports = class extends EventEmitter {
 
     return new Promise((resolve, reject) => {
       // Send the command
-      self._request(cmd, 'getPowerUsage', retry)
-        .then(response => {
+      self
+        ._request(cmd, 'getPowerUsage', retry)
+        .then((response) => {
           // Check this is the correct response type
-          if (response[10] !== 0xC1) {
+          if (response[10] !== 0xc1) {
             return reject(new Error('Invalid response'));
           }
 
@@ -162,12 +191,15 @@ module.exports = class extends EventEmitter {
 
           resolve(reporter(parsedData));
         })
-        .catch(error => {
-          logger.debug(`AC.getPowerUsage: 20-byte group 4 request failed (${error.message}); trying legacy 6-byte request`);
+        .catch((error) => {
+          logger.debug(
+            `AC.getPowerUsage: 20-byte group 4 request failed (${error.message}); trying legacy 6-byte request`
+          );
 
-          self._request(createLegacyPowerUsageCommand(), 'getPowerUsageLegacy', retry)
-            .then(response => {
-              if (response[10] !== 0xC1) {
+          self
+            ._request(createLegacyPowerUsageCommand(), 'getPowerUsageLegacy', retry)
+            .then((response) => {
+              if (response[10] !== 0xc1) {
                 return reject(new Error('Invalid response'));
               }
 
@@ -180,14 +212,52 @@ module.exports = class extends EventEmitter {
 
               resolve(reporter(parsedData));
             })
-            .catch(legacyError => {
+            .catch((legacyError) => {
               reject(legacyError);
             });
         });
     });
   }
 
-  getGroup5Data (retry = 0) {
+  getUnknownGroupData(groupByte, retry = 0) {
+    const self = this;
+
+    logger.silly(`AC.getUnknownGroupData: Entering for 0x${groupByte.toString(16)}`);
+
+    const cmd = createGroupDataCommandByByte(groupByte);
+
+    return new Promise((resolve, reject) => {
+      self
+        ._request(cmd, `getUnknownGroupData:0x${groupByte.toString(16).padStart(2, '0')}`, retry)
+        .then((response) => {
+          const payload = response.subarray(10, response.length - 2);
+          const responseId = response[10];
+          const responseGroupByte = payload.length > 3 ? payload[3] : groupByte;
+
+          if (responseId !== 0xc1) {
+            return reject(new Error('Invalid response'));
+          }
+
+          const parsedData = self._parseResponse(response);
+          const rawData = {
+            ...parsedData,
+            rawFrameHex: response.toString('hex'),
+            payloadHex: payload.toString('hex'),
+            responseId,
+            groupByte: responseGroupByte,
+            rawBytes: buildRawByteMap(payload),
+            analogCandidates: buildAnalogCandidates(payload),
+          };
+
+          resolve(rawData);
+        })
+        .catch((error) => {
+          reject(error);
+        });
+    });
+  }
+
+  getGroup5Data(retry = 0) {
     const self = this;
 
     logger.silly('AC.getGroup5Data: Entering');
@@ -195,9 +265,10 @@ module.exports = class extends EventEmitter {
     const cmd = createGroupDataCommand(5);
 
     return new Promise((resolve, reject) => {
-      self._request(cmd, 'getGroup5Data', retry)
-        .then(response => {
-          if (response[10] !== 0xC1) {
+      self
+        ._request(cmd, 'getGroup5Data', retry)
+        .then((response) => {
+          if (response[10] !== 0xc1) {
             return reject(new Error('Invalid response'));
           }
 
@@ -210,22 +281,20 @@ module.exports = class extends EventEmitter {
 
           resolve(reporter(parsedData));
         })
-        .catch(error => {
+        .catch((error) => {
           reject(error);
         });
     });
   }
 
-  getStatus (retry = 0) {
+  getStatus(retry = 0) {
     const self = this;
 
     logger.silly('AC.getStatus: Entering');
 
     let cmd = Buffer.from([
-      0x41, 0x81, 0x00, 0xFF, 0x03, 0xFF,
-      0x00, 0x02, 0x00, 0x00, 0x00, 0x00,
-      0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-      0x00, 0x00, 0x03
+      0x41, 0x81, 0x00, 0xff, 0x03, 0xff, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x03,
     ]);
 
     // The Midea Air app uses no protocol id for this command
@@ -233,10 +302,11 @@ module.exports = class extends EventEmitter {
 
     return new Promise((resolve, reject) => {
       // Send the command
-      self._request(cmd, 'getStatus', retry)
-        .then(response => {
+      self
+        ._request(cmd, 'getStatus', retry)
+        .then((response) => {
           // Check this is the correct response type
-          if (response[10] !== 0xC0) {
+          if (response[10] !== 0xc0) {
             logger.error(`AC.getStatus: Invalid response (${response.toString('hex')})`);
             return reject(new Error('Invalid response'));
           }
@@ -252,13 +322,13 @@ module.exports = class extends EventEmitter {
 
           resolve(reporter(parsedData));
         })
-        .catch(error => {
+        .catch((error) => {
           reject(error);
         });
     });
   }
 
-  setStatus (properties = {}, retry = 0) {
+  setStatus(properties = {}, retry = 0) {
     const self = this;
 
     logger.silly(`AC.setStatus: Entering with ${JSON.stringify(properties)}`);
@@ -278,7 +348,7 @@ module.exports = class extends EventEmitter {
         dry: 3,
         heat: 4,
         fanonly: 5,
-        customdry: 6
+        customdry: 6,
       };
 
       const fanSpeed = {
@@ -287,7 +357,7 @@ module.exports = class extends EventEmitter {
         low: 40,
         medium: 60,
         high: 80,
-        fixed: 101
+        fixed: 101,
       };
 
       for (const property in properties) {
@@ -305,21 +375,33 @@ module.exports = class extends EventEmitter {
               }
             }
             if (typeof properties[property] === 'string' && !fanSpeed[properties[property]]) {
-              return reject(new errors.OutOfRangeError('fanSpeed must be one of: auto, silent, low, medium, high or fixed'));
+              return reject(
+                new errors.OutOfRangeError(
+                  'fanSpeed must be one of: auto, silent, low, medium, high or fixed'
+                )
+              );
             }
 
-            logger.debug(`AC.setStatus: Set fan speed to ${typeof properties[property] === 'number' ? properties[property] : fanSpeed[properties[property]]}`);
+            logger.debug(
+              `AC.setStatus: Set fan speed to ${typeof properties[property] === 'number' ? properties[property] : fanSpeed[properties[property]]}`
+            );
 
-            status.fanSpeed = typeof properties[property] === 'number' ? properties[property] : fanSpeed[properties[property]];
+            status.fanSpeed =
+              typeof properties[property] === 'number'
+                ? properties[property]
+                : fanSpeed[properties[property]];
             break;
 
-          case 'frostProtectionMode': { // Requires capability frostProtectionMode and only available when mode is heat
-            const isHeatMode = value => value === 'heat' || value === 4;
+          case 'frostProtectionMode': {
+            // Requires capability frostProtectionMode and only available when mode is heat
+            const isHeatMode = (value) => value === 'heat' || value === 4;
             const requestedValue = properties[property] === true;
 
             if (!isHeatMode(status.mode) && !isHeatMode(properties.mode)) {
               if (requestedValue) {
-                logger.warn('AC.setStatus: Ignoring frost protection activation because the device is not in heat mode');
+                logger.warn(
+                  'AC.setStatus: Ignoring frost protection activation because the device is not in heat mode'
+                );
               }
 
               status.frostProtectionMode = false;
@@ -334,7 +416,9 @@ module.exports = class extends EventEmitter {
 
           case 'humiditySetpoint':
             if (properties[property] < 35 || properties[property] > 85) {
-              return reject(new errors.OutOfRangeError('The humiditySetpoint must be between 35 - 85%'));
+              return reject(
+                new errors.OutOfRangeError('The humiditySetpoint must be between 35 - 85%')
+              );
             }
 
             logger.debug(`AC.setStatus: Set humiditySetpoint to ${properties[property]}`);
@@ -351,7 +435,11 @@ module.exports = class extends EventEmitter {
           case 'mode':
             // FIXME: Only allow modes that are available according to the capabilities
             if (!mode[properties[property]]) {
-              return reject(new errors.OutOfRangeError('Mode must be one of: auto, cool, dry, heat, fanonly or customdry'));
+              return reject(
+                new errors.OutOfRangeError(
+                  'Mode must be one of: auto, cool, dry, heat, fanonly or customdry'
+                )
+              );
             }
 
             logger.debug(`AC.setStatus: Set mode to ${mode[properties[property]]}`);
@@ -366,14 +454,20 @@ module.exports = class extends EventEmitter {
             break;
 
           case 'temperatureSetpoint':
-            if ((status.temperatureUnit === 0 || properties.temperatureUnit === 'celsius') &&
-              (properties[property] < 16 || properties[property] > 31)) {
-              return reject(new errors.OutOfRangeError('The temperatureSetpoint must be between 16 - 31°C'));
+            if (
+              (status.temperatureUnit === 0 || properties.temperatureUnit === 'celsius') &&
+              (properties[property] < 16 || properties[property] > 31)
+            ) {
+              return reject(
+                new errors.OutOfRangeError('The temperatureSetpoint must be between 16 - 31°C')
+              );
             }
 
             if (status.temperatureUnit === 1 || properties.temperatureUnit === 'fahrenheit') {
               if (properties[property] < 60 || properties[property] > 87) {
-                return reject(new errors.OutOfRangeError('The temperatureSetpoint must be between 60 - 87°F'));
+                return reject(
+                  new errors.OutOfRangeError('The temperatureSetpoint must be between 60 - 87°F')
+                );
               }
             }
 
@@ -396,10 +490,16 @@ module.exports = class extends EventEmitter {
 
           case 'temperatureUnit':
             if (properties[property] !== 'fahrenheit' && properties[property] !== 'celsius') {
-              return reject(new errors.OutOfRangeError('The temperatureUnit must either be fahrenheit or celsius'));
+              return reject(
+                new errors.OutOfRangeError(
+                  'The temperatureUnit must either be fahrenheit or celsius'
+                )
+              );
             }
 
-            logger.debug(`AC.setStatus: Set temperature unit to ${properties[property]} => ${properties[property] === 'fahrenheit' ? 0x01 : 0x00}`);
+            logger.debug(
+              `AC.setStatus: Set temperature unit to ${properties[property]} => ${properties[property] === 'fahrenheit' ? 0x01 : 0x00}`
+            );
 
             status.temperatureUnit = properties[property] === 'fahrenheit' ? 0x01 : 0x00;
             break;
@@ -417,7 +517,9 @@ module.exports = class extends EventEmitter {
             break;
 
           default:
-            return reject(new errors.OutOfRangeError(`Unsupported property to be set (${property})`));
+            return reject(
+              new errors.OutOfRangeError(`Unsupported property to be set (${property})`)
+            );
         }
       }
 
@@ -434,9 +536,14 @@ module.exports = class extends EventEmitter {
       // G: remoteControlMode (0: remote control, 1: PC) (followMe active or not???)
       // H: powerOn
       status.remoteControlMode = 1;
-      cmd[1] = (status.beep ? 0x40 : 0x00) | (status.fastCheck ? 0x20 : 0x00) |
-        (status.timerMode ? 0x10 : 0x00) | (status.childSleep ? 0x08 : 0x00) |
-          (status.resume ? 0x04 : 0x00) | 0x02 | (status.powerOn ? 0x01 : 0x00);
+      cmd[1] =
+        (status.beep ? 0x40 : 0x00) |
+        (status.fastCheck ? 0x20 : 0x00) |
+        (status.timerMode ? 0x10 : 0x00) |
+        (status.childSleep ? 0x08 : 0x00) |
+        (status.resume ? 0x04 : 0x00) |
+        0x02 |
+        (status.powerOn ? 0x01 : 0x00);
 
       // Byte 2
       // AAABCCCC
@@ -453,7 +560,7 @@ module.exports = class extends EventEmitter {
       let setpoint = status.temperatureSetpoint;
       if (setpoint > 60) {
         // Convert Fahrenheit to Celsius
-        setpoint = Math.ceil((setpoint - 32) / 1.8 * 2) / 2;
+        setpoint = Math.ceil(((setpoint - 32) / 1.8) * 2) / 2;
       }
 
       cmd[2] = (status.mode << 5) | (setpoint % 1 ? 0x10 : 0x00) | Math.floor(setpoint - 16);
@@ -490,7 +597,7 @@ module.exports = class extends EventEmitter {
       //   onMinutesH ? onMinutesH-- : 0;
       // }
 
-      cmd[4] = (status.onTimer ? 0x80 : 0x00) | ((onHours & 0x1F) << 2) | (onMinutesH & 0x03);
+      cmd[4] = (status.onTimer ? 0x80 : 0x00) | ((onHours & 0x1f) << 2) | (onMinutesH & 0x03);
 
       // Byte 5
       // ABBBBBCC
@@ -513,24 +620,27 @@ module.exports = class extends EventEmitter {
       //   offMinutesL = 0;
       //   offMinutesH ? offMinutesH-- : 0;
       // }
-      cmd[15] = (status.offTimer ? 0x80 : 0x00) | ((offHours & 0x1F) << 2) | (offMinutesH & 0x03);
+      cmd[15] = (status.offTimer ? 0x80 : 0x00) | ((offHours & 0x1f) << 2) | (offMinutesH & 0x03);
 
       // Byte 6
       // AAAABBBB
       // A: Bits 2-5 of minutes on timer
       // B: Bits 2-5 of minutes off timer
-      cmd[16] = ((onMinutesL & 0x0F) << 4) | (offMinutesL & 0x0F);
+      cmd[16] = ((onMinutesL & 0x0f) << 4) | (offMinutesL & 0x0f);
 
       // ABBBBBCC
       // A: offTimerActive
       // B: offTimerHours
       // C: offTimerMinutes bits 0/1
-      cmd[5] = (status.offTimerActive ? 0x80 : 0x00) | (status.offTimerHours << 2) | (status.offTimerMinutes & 0x03);
+      cmd[5] =
+        (status.offTimerActive ? 0x80 : 0x00) |
+        (status.offTimerHours << 2) |
+        (status.offTimerMinutes & 0x03);
 
       // AAAABBBB
       // A: timerOffMinutes bits 2-6
       // B: timerOffMinutes bits 2-6
-      cmd[6] = ((status.timerOnMinutes & 0x2C) << 2) | (status.timerOffMinutes & 0x2C >> 2);
+      cmd[6] = ((status.timerOnMinutes & 0x2c) << 2) | (status.timerOffMinutes & (0x2c >> 2));
 
       // Byte 7
       // AAAABBCC
@@ -555,7 +665,7 @@ module.exports = class extends EventEmitter {
       // ???? comfort wind (0x3-left and right wind) 0x32
       // ???? comfort wind (0x3-right and left wind) 0x31
       // LEFTRIGHT: 51=0x33, 63=0x3F
-      cmd[7] = 0x30 | (status.updownFan ? 0x0C : 0x00) | (status.leftrightFan ? 0x03 : 0x00);
+      cmd[7] = 0x30 | (status.updownFan ? 0x0c : 0x00) | (status.leftrightFan ? 0x03 : 0x00);
 
       // Byte 8
       // ABCDEFGG
@@ -566,10 +676,14 @@ module.exports = class extends EventEmitter {
       // E: save/PowerSaving (not used?)
       // F: alarmSleep (not used?)
       // G: cosySleep/SleepMode (00=No comfortable sleep, 01=Sleep well 1, 02=Sleep well 2, 03=Sleep 3) (not used?)
-      cmd[8] = (status.feelOwn ? 0x80 : 0x00) | (status.powerSaver ? 0x40 : 0x00) |
-               (status.turboMode ? 0x20 : 0x00) | (status.lowFrequencyFan ? 0x10 : 0x00) |
-               (status.save ? 0x08 : 0x00) | (status.alarmSleep ? 0x04 : 0x00) |
-               (status.cosySleep & 0x03);
+      cmd[8] =
+        (status.feelOwn ? 0x80 : 0x00) |
+        (status.powerSaver ? 0x40 : 0x00) |
+        (status.turboMode ? 0x20 : 0x00) |
+        (status.lowFrequencyFan ? 0x10 : 0x00) |
+        (status.save ? 0x08 : 0x00) |
+        (status.alarmSleep ? 0x04 : 0x00) |
+        (status.cosySleep & 0x03);
 
       // Byte 9
       // ABCDEFGH
@@ -581,10 +695,15 @@ module.exports = class extends EventEmitter {
       // F: dryClean (not used?)
       // G: exchangeAir/Ventilation (not used?)
       // H: wiseEye/smartEye (not used?)
-      cmd[9] = (status.ecoMode ? 0x80 : 0x00) | (status.changeCosySlep ? 0x40 : 0x00) |
-               (status.purify ? 0x40 : 0x00) | (status.ptcButton ? 0x10 : 0x00) |
-               (status.ptcHeater ? 0x08 : 0x00) | (status.dryClean ? 0x04 : 0x00) |
-               (status.ventilation ? 0x02 : 0x00) | (status.smartEye ? 0x01 : 0x00);
+      cmd[9] =
+        (status.ecoMode ? 0x80 : 0x00) |
+        (status.changeCosySlep ? 0x40 : 0x00) |
+        (status.purify ? 0x40 : 0x00) |
+        (status.ptcButton ? 0x10 : 0x00) |
+        (status.ptcHeater ? 0x08 : 0x00) |
+        (status.dryClean ? 0x04 : 0x00) |
+        (status.ventilation ? 0x02 : 0x00) |
+        (status.smartEye ? 0x01 : 0x00);
 
       // Byte 10
       // ABCDEFGH
@@ -596,10 +715,15 @@ module.exports = class extends EventEmitter {
       // F: temperatureUnit (1: fahrenheit / 0: celsius)
       // G: turboMode
       // H: sleepMode
-      cmd[10] = (status.cleanFanTime ? 0x80 : 0x00) | (status.dustFull ? 0x40 : 0x00) |
-                (status.peakValleyElectricitySaving ? 0x20 : 0x00) | (status.nightLight ? 0x10 : 0x00) |
-                (status.catchCold ? 0x08 : 0x00) | (status.temperatureUnit ? 0x04 : 0x00) |
-                (status.turboMode ? 0x02 : 0x00) | (status.sleepMode ? 0x01 : 0x00);
+      cmd[10] =
+        (status.cleanFanTime ? 0x80 : 0x00) |
+        (status.dustFull ? 0x40 : 0x00) |
+        (status.peakValleyElectricitySaving ? 0x20 : 0x00) |
+        (status.nightLight ? 0x10 : 0x00) |
+        (status.catchCold ? 0x08 : 0x00) |
+        (status.temperatureUnit ? 0x04 : 0x00) |
+        (status.turboMode ? 0x02 : 0x00) |
+        (status.sleepMode ? 0x01 : 0x00);
 
       // Byte 11
       // AAAABBBB
@@ -649,7 +773,7 @@ module.exports = class extends EventEmitter {
       // AAABBBBB
       // A: bit 0-2 of PMV
       // B: setNewTemperature (not used?) (0=invalid, 1=13deg, 2=14deg, ...., 22=34deg)
-      cmd[18] = (status.setNewTemperature - 12) & 0x1F;
+      cmd[18] = (status.setNewTemperature - 12) & 0x1f;
 
       // Byte 19
       // ABBBBBBB
@@ -668,8 +792,11 @@ module.exports = class extends EventEmitter {
       // B: dualControl/double_temp (not used?)
       // C: temp (not used?)
       // D: Decimal (not used?)
-      cmd[21] = (status.frostProtectionMode ? 0x80 : 0x00) | (status.dualControl ? 0x40 : 0x00) |
-                ((status.temp & 0x1F) << 1) | status.tempDot;
+      cmd[21] =
+        (status.frostProtectionMode ? 0x80 : 0x00) |
+        (status.dualControl ? 0x40 : 0x00) |
+        ((status.temp & 0x1f) << 1) |
+        status.tempDot;
 
       // Byte 22
       // AAABCDEF
@@ -679,8 +806,13 @@ module.exports = class extends EventEmitter {
       // D: braceletControl (home mode status???)
       // E: braceletSleep (Link state between bracelet and sleep comfort???)
       // F: keepWarm
-      cmd[22] = 0x80 | (status.windBlowing ? 0x10 : 0x00) | (status.smartWind ? 0x08 : 0x00) | (status.braceletControl ? 0x04 : 0x00) |
-                (status.braceletSleep ? 0x02 : 0x00) | (status.keepWarm ? 0x01 : 0x00);
+      cmd[22] =
+        0x80 |
+        (status.windBlowing ? 0x10 : 0x00) |
+        (status.smartWind ? 0x08 : 0x00) |
+        (status.braceletControl ? 0x04 : 0x00) |
+        (status.braceletSleep ? 0x02 : 0x00) |
+        (status.keepWarm ? 0x01 : 0x00);
 
       // Byte 23
 
@@ -692,8 +824,9 @@ module.exports = class extends EventEmitter {
       cmd = createCommand(cmd, 0x02);
 
       // Send the command
-      self._request(cmd, 'setStatus', retry)
-        .then(response => {
+      self
+        ._request(cmd, 'setStatus', retry)
+        .then((response) => {
           const parsedData = self._parseResponse(response);
 
           // Update in-memory state
@@ -705,7 +838,7 @@ module.exports = class extends EventEmitter {
 
           resolve(reporter(parsedData));
         })
-        .catch(error => {
+        .catch((error) => {
           reject(error);
         });
     });

--- a/lib/node-mideahvac/lib/serialbridge.js
+++ b/lib/node-mideahvac/lib/serialbridge.js
@@ -10,12 +10,14 @@ const errors = require('./errors');
 
 // Add a transport as fall back when no parent logger has been initialized
 // to prevent the error: "Attempt to write logs with no transports"
-logger.add(new logger.transports.Console({
-  level: 'none'
-}));
+logger.add(
+  new logger.transports.Console({
+    level: 'none',
+  })
+);
 
 module.exports = class extends AC {
-  constructor (options = {}) {
+  constructor(options = {}) {
     super();
 
     if (!options.host || !options.port) {
@@ -33,7 +35,7 @@ module.exports = class extends AC {
     this._rcvBuf = Buffer.alloc(0);
     this.parserOptions = {
       exposeRawBytes: !!options.exposeRawBytes,
-      exposeAnalogCandidates: !!options.exposeAnalogCandidates
+      exposeAnalogCandidates: !!options.exposeAnalogCandidates,
     };
 
     this._cmdTimer = null;
@@ -43,7 +45,7 @@ module.exports = class extends AC {
     this.logger = logger.child({ label: `deviceId=${this.id}` });
   }
 
-  _connect () {
+  _connect() {
     const self = this;
 
     logger.debug('SerialBridge: Connecting');
@@ -60,12 +62,17 @@ module.exports = class extends AC {
 
         // Send the network notification message each 2 minutes (use unref to prevent this is keeping the process alive and stalls the unit test)
         clearTimeout(self.networkUpdateTimer);
-        self.networkUpdateTimer = setInterval(self => {
-          self.sendNetworkStatusNotification()
-            .catch(error => {
-              logger.error(`SerialBridge._connect: Failed to send network status notification (${error.message})`);
+        self.networkUpdateTimer = setInterval(
+          (self) => {
+            self.sendNetworkStatusNotification().catch((error) => {
+              logger.error(
+                `SerialBridge._connect: Failed to send network status notification (${error.message})`
+              );
             });
-        }, 120000, self).unref();
+          },
+          120000,
+          self
+        ).unref();
 
         resolve();
       });
@@ -106,14 +113,16 @@ module.exports = class extends AC {
     });
   }
 
-  _extractFrames (data) {
+  _extractFrames(data) {
     this._rcvBuf = Buffer.concat([this._rcvBuf, data]);
     const frames = [];
 
     while (this._rcvBuf.length > 0) {
-      const start = this._rcvBuf.indexOf(0xAA);
+      const start = this._rcvBuf.indexOf(0xaa);
       if (start < 0) {
-        logger.error(`SerialBridge._extractFrames: Dropping ${this._rcvBuf.length} byte(s) before sync header`);
+        logger.error(
+          `SerialBridge._extractFrames: Dropping ${this._rcvBuf.length} byte(s) before sync header`
+        );
         this._rcvBuf = Buffer.alloc(0);
         break;
       }
@@ -147,14 +156,16 @@ module.exports = class extends AC {
     return frames;
   }
 
-  _handleFrame (data) {
+  _handleFrame(data) {
     logger.debug(`SerialBridge.connect: Processing frame: ${data.toString('hex')}`);
 
     // TODO: Add check for CRC8 and checksum
 
     // When command is in progress, call the response handler for this command
     if (this._cmdInProgress) {
-      logger.silly(`SerialBridge.connect: Calling handler for the command '${this._cmdQueue[0].label}' in progress`);
+      logger.silly(
+        `SerialBridge.connect: Calling handler for the command '${this._cmdQueue[0].label}' in progress`
+      );
 
       this._cmdQueue[0].handler(null, data);
 
@@ -172,7 +183,7 @@ module.exports = class extends AC {
     }
   }
 
-  _processQueue () {
+  _processQueue() {
     const self = this;
 
     logger.silly('SerialBridge._processQueue: Entering');
@@ -189,16 +200,20 @@ module.exports = class extends AC {
 
     logger.debug(`SerialBridge._processQueue: Sending '${self._cmdQueue[0].label}' command`);
 
-    self._connection.write(self._cmdQueue[0].cmd, error => {
+    self._connection.write(self._cmdQueue[0].cmd, (error) => {
       if (error) {
-        self.logger.error(`SerialBridge._processQueue: Error writing command '${self._cmdQueue[0].label}' (${error.message})`);
+        self.logger.error(
+          `SerialBridge._processQueue: Error writing command '${self._cmdQueue[0].label}' (${error.message})`
+        );
 
         self._cmdInProgress = false;
 
         if (self._cmdQueue[0].retry) {
           self._cmdQueue[0].retry--;
 
-          self.logger.info(`SerialBridge._processQueue: Retry ${self._cmdQueue[0].label}, ${self._cmdQueue[0].retry} retries left`);
+          self.logger.info(
+            `SerialBridge._processQueue: Retry ${self._cmdQueue[0].label}, ${self._cmdQueue[0].retry} retries left`
+          );
 
           // Delay before sending the command to prevent flooding
         } else {
@@ -216,52 +231,64 @@ module.exports = class extends AC {
       }
 
       // Start timer to prevent hanging waiting for a response to a command
-      self._cmdTimer = setTimeout(self => {
-        self.logger.error(`SerialBridge._processQueue: No response received in time for '${self._cmdQueue[0].label}' command`);
+      self._cmdTimer = setTimeout(
+        (self) => {
+          const label = self._cmdQueue[0].label;
+          const message = `SerialBridge._processQueue: No response received in time for '${label}' command`;
+          if (typeof label === 'string' && label.startsWith('getUnknownGroupData:')) {
+            self.logger.debug(message);
+          } else {
+            self.logger.error(message);
+          }
 
-        self._cmdInProgress = false;
+          self._cmdInProgress = false;
 
-        if (self._cmdQueue[0].retry) {
-          self._cmdQueue[0].retry--;
+          if (self._cmdQueue[0].retry) {
+            self._cmdQueue[0].retry--;
 
-          self.logger.info(`SerialBridge._write: Retry ${self._cmdQueue[0].label}, ${self._cmdQueue[0].retry} retries left`);
+            self.logger.info(
+              `SerialBridge._write: Retry ${self._cmdQueue[0].label}, ${self._cmdQueue[0].retry} retries left`
+            );
 
-          // Delay before sending the command to prevent flooding
-        } else {
-          self._cmdQueue[0].handler(new errors.TimeoutError('No response received'));
+            // Delay before sending the command to prevent flooding
+          } else {
+            self._cmdQueue[0].handler(new errors.TimeoutError('No response received'));
 
-          // Remove previous command from queue
-          self._cmdQueue.shift();
-        }
+            // Remove previous command from queue
+            self._cmdQueue.shift();
+          }
 
-        setTimeout(() => {
-          self._processQueue();
-        }, 500);
-      }, 2000, self);
+          setTimeout(() => {
+            self._processQueue();
+          }, 500);
+        },
+        2000,
+        self
+      );
     });
   }
 
-  _queueCommand (options, handler = () => { }) {
+  _queueCommand(options, handler = () => {}) {
     const self = this;
 
     self._cmdQueue.push({
       cmd: options.cmd,
       label: options.label,
       retry: options.retry,
-      handler
+      handler,
     });
 
     self._processQueue();
   }
 
-  _request (cmd, label = 'unknown', retry = 0) {
+  _request(cmd, label = 'unknown', retry = 0) {
     const self = this;
 
     return new Promise(async (resolve, reject) => {
       const options = {
         cmd,
         label,
-        retry
+        retry,
       };
 
       if (self._cmdQueue.length === self._maxQueueDepth) {
@@ -284,25 +311,26 @@ module.exports = class extends AC {
     });
   }
 
-  getElectronicId () {
+  getElectronicId() {
     const self = this;
 
     let cmd = Buffer.from([0x00]);
 
-    cmd = createCommand(cmd, 0x07, 0x03, 0xFF, false);
+    cmd = createCommand(cmd, 0x07, 0x03, 0xff, false);
 
     return new Promise((resolve, reject) => {
-      self._request(cmd, 'getElectronicId')
-        .then(response => {
+      self
+        ._request(cmd, 'getElectronicId')
+        .then((response) => {
           resolve(response);
         })
-        .catch(error => {
+        .catch((error) => {
           reject(error);
         });
     });
   }
 
-  async initialize () {
+  async initialize() {
     const self = this;
     let status = {};
     let capabilities = {};
@@ -310,50 +338,62 @@ module.exports = class extends AC {
     logger.debug('SerialBridge.initialize: Entering');
 
     // Send network status notification in order to have the WiFi symbol shown in the display
-    await self.sendNetworkStatusNotification()
-      .catch(error => {
-        logger.error(`SerialBridge.initialize: Failed to send network status notification for ${self.id} - ${error.message}`);
-      });
+    await self.sendNetworkStatusNotification().catch((error) => {
+      logger.error(
+        `SerialBridge.initialize: Failed to send network status notification for ${self.id} - ${error.message}`
+      );
+    });
 
-    capabilities = await self.getCapabilities(true)
-      .catch(error => {
-        logger.error(`SerialBridge.initialize: Failed to get capabilities of ${self.id} - ${error.message}`);
-      });
+    capabilities = await self.getCapabilities(true).catch((error) => {
+      logger.error(
+        `SerialBridge.initialize: Failed to get capabilities of ${self.id} - ${error.message}`
+      );
+    });
 
     if (capabilities) {
-      logger.silly(`SerialBridge.initialize: Capabilities of ${self.id} - ${JSON.stringify(capabilities)}`);
+      logger.silly(
+        `SerialBridge.initialize: Capabilities of ${self.id} - ${JSON.stringify(capabilities)}`
+      );
     }
 
-    status = await self.getStatus(true, false)
-      .catch(error => {
-        throw logger.error(`SerialBridge.initialize: Failed to get current status of ${self.id} - ${error.message}`);
-      });
+    status = await self.getStatus(true, false).catch((error) => {
+      throw logger.error(
+        `SerialBridge.initialize: Failed to get current status of ${self.id} - ${error.message}`
+      );
+    });
 
-    logger.silly(`SerialBridge.initialize: Current status of ${self.id} - ${JSON.stringify(status)}`);
+    logger.silly(
+      `SerialBridge.initialize: Current status of ${self.id} - ${JSON.stringify(status)}`
+    );
 
     // Send the network notification message each 2 minutes (use unref to prevent this is keeping the process alive and stalls the unit test)
-    setInterval(self => {
-      self.sendNetworkStatusNotification()
-        .catch(error => {
-          logger.error(`SerialBridge.initialize: Failed to send network status notification for ${self.id} - ${error.message}`);
+    setInterval(
+      (self) => {
+        self.sendNetworkStatusNotification().catch((error) => {
+          logger.error(
+            `SerialBridge.initialize: Failed to send network status notification for ${self.id} - ${error.message}`
+          );
         });
-    }, 120000, self).unref();
+      },
+      120000,
+      self
+    ).unref();
 
     self.emit('initialized', {
       status,
-      capabilities
+      capabilities,
     });
 
     return {
       status,
-      capabilities
+      capabilities,
     };
   }
 
   // This message is send when the status of the network connection changes
   // or on response on a request of the AC unit (message type 0x63)
   // Sending this update show the WiFi symbol on the display of the unit
-  sendNetworkStatusNotification () {
+  sendNetworkStatusNotification() {
     const self = this;
     let cmd = Buffer.alloc(20);
 
@@ -401,7 +441,7 @@ module.exports = class extends AC {
     // - 0x03, medium
     // - 0x04, strong
     // - 0xFF, RF is not supported
-    cmd[7] = 0xFF;
+    cmd[7] = 0xff;
 
     // Byte 8: Router status
     // - 0x00, wireless router is connected
@@ -442,19 +482,20 @@ module.exports = class extends AC {
     cmd[18] = 0x00;
     cmd[19] = 0x00;
 
-    cmd = createCommand(cmd, 0x0D, 0x03, 0xAC, false);
+    cmd = createCommand(cmd, 0x0d, 0x03, 0xac, false);
 
     return new Promise((resolve, reject) => {
-      self._request(cmd, 'sendNetworkStatusNotification')
-        .then(response => {
+      self
+        ._request(cmd, 'sendNetworkStatusNotification')
+        .then((response) => {
           // Check this is the correct response type
-          if (response[10] !== 0x0D) {
+          if (response[10] !== 0x0d) {
             return reject(new Error('Invalid response'));
           }
 
           resolve(response);
         })
-        .catch(error => {
+        .catch((error) => {
           reject(error);
         });
     });

--- a/lib/polling-config.js
+++ b/lib/polling-config.js
@@ -25,6 +25,117 @@ const POLLING_METHODS = [
 
 const POLLING_METHOD_MAP = new Map(POLLING_METHODS.map((entry) => [entry.id, entry]));
 
+const UNKNOWN_GROUP_MIN = 0x40;
+const UNKNOWN_GROUP_MAX = 0x4f;
+const UNKNOWN_GROUP_MAX_COUNT = 8;
+const UNKNOWN_GROUP_MIN_INTERVAL = 10;
+
+function normalizeUnknownGroupPollingInterval(value, fallback = 60) {
+  const numericValue = Number(value);
+  if (!Number.isFinite(numericValue)) {
+    return fallback;
+  }
+
+  return Math.max(Math.round(numericValue), UNKNOWN_GROUP_MIN_INTERVAL);
+}
+
+function extractUnknownGroupTokens(value) {
+  if (value === null || value === undefined || value === '') {
+    return [];
+  }
+
+  if (typeof value === 'number' || typeof value === 'bigint') {
+    return [String(value)];
+  }
+
+  if (typeof value === 'string') {
+    return value
+      .split(/[\s,;]+/)
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+
+  if (Array.isArray(value)) {
+    const tokens = [];
+    for (const entry of value) {
+      if (entry && typeof entry === 'object' && !Array.isArray(entry)) {
+        const candidate =
+          entry.groupByte ?? entry.groupId ?? entry.group ?? entry.id ?? entry.value ?? entry.byte;
+        tokens.push(...extractUnknownGroupTokens(candidate));
+      } else {
+        tokens.push(...extractUnknownGroupTokens(entry));
+      }
+    }
+    return tokens;
+  }
+
+  if (typeof value === 'object') {
+    return extractUnknownGroupTokens(
+      value.groupByte ?? value.groupId ?? value.group ?? value.id ?? value.value ?? value.byte
+    );
+  }
+
+  return [];
+}
+
+function parseUnknownGroupToken(token) {
+  const normalized = String(token).trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+
+  if (/^0x[0-9a-f]{1,2}$/.test(normalized)) {
+    return Number.parseInt(normalized.slice(2), 16);
+  }
+
+  if (/^[0-9a-f]{2}$/.test(normalized)) {
+    return Number.parseInt(normalized, 16);
+  }
+
+  return null;
+}
+
+function parseUnknownGroupIds(value, options = {}) {
+  const maxGroups = options.maxGroups || UNKNOWN_GROUP_MAX_COUNT;
+  const tokens = extractUnknownGroupTokens(value);
+  const groups = [];
+  const invalid = [];
+  const duplicates = [];
+  const seen = new Set();
+  let truncated = false;
+
+  for (const token of tokens) {
+    const parsed = parseUnknownGroupToken(token);
+    if (parsed === null || parsed < UNKNOWN_GROUP_MIN || parsed > UNKNOWN_GROUP_MAX) {
+      invalid.push(String(token));
+      continue;
+    }
+
+    if (seen.has(parsed)) {
+      duplicates.push(parsed);
+      continue;
+    }
+
+    if (groups.length >= maxGroups) {
+      truncated = true;
+      continue;
+    }
+
+    seen.add(parsed);
+    groups.push(parsed);
+  }
+
+  return { groups, invalid, duplicates, truncated };
+}
+
+function formatUnknownGroupId(groupByte) {
+  const numericValue = Number(groupByte);
+  if (!Number.isFinite(numericValue)) {
+    return '??';
+  }
+  return numericValue.toString(16).padStart(2, '0').toUpperCase();
+}
+
 function normalizeBooleanValue(value) {
   if (typeof value === 'string') {
     const normalized = value.trim().toLowerCase();
@@ -117,7 +228,14 @@ function normalizePollingRequests(config = {}) {
 module.exports = {
   POLLING_METHODS,
   POLLING_METHOD_MAP,
+  UNKNOWN_GROUP_MAX,
+  UNKNOWN_GROUP_MAX_COUNT,
+  UNKNOWN_GROUP_MIN,
+  UNKNOWN_GROUP_MIN_INTERVAL,
   describePollingEntries,
+  formatUnknownGroupId,
   normalizeBooleanValue,
   normalizePollingRequests,
+  normalizeUnknownGroupPollingInterval,
+  parseUnknownGroupIds,
 };

--- a/main.js
+++ b/main.js
@@ -6,9 +6,13 @@ const { MideaSerialBridge } = require('./lib/midea-serial-bridge');
 const { DATA_POINTS } = require('./lib/datapoints');
 const {
   POLLING_METHOD_MAP,
+  UNKNOWN_GROUP_MAX_COUNT,
   describePollingEntries,
+  formatUnknownGroupId,
   normalizeBooleanValue,
   normalizePollingRequests,
+  normalizeUnknownGroupPollingInterval,
+  parseUnknownGroupIds,
 } = require('./lib/polling-config');
 const {
   MODE_ALIASES,
@@ -91,6 +95,8 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
     this._restartTimer = null;
     this._knownCapabilityStates = new Set();
     this._knownRawStatusStates = new Set();
+    this._knownUnknownGroupRawStates = new Set();
+    this._unknownGroupPollingInProgress = false;
     this.valueRepresentation = { mode: false, fanSpeed: false, swingMode: false };
 
     this._unhandledRejectionHandler = (reason) => {
@@ -184,6 +190,12 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
       this.bridge.on('group5Data', (group5Data) => {
         this._applyGroup5Data(group5Data).catch((error) => {
           this.log.debug(`Failed to process group 5 update: ${this._formatError(error)}`);
+        });
+      });
+
+      this.bridge.on('unknownGroupData', (groupData) => {
+        this._applyUnknownGroupData(groupData).catch((error) => {
+          this.log.debug(`Failed to process unknown group update: ${this._formatError(error)}`);
         });
       });
 
@@ -345,6 +357,14 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
       type: 'channel',
       common: {
         name: 'Raw status values',
+      },
+      native: {},
+    });
+
+    await this.setObjectNotExistsAsync('statusRaw.unknownGroups', {
+      type: 'channel',
+      common: {
+        name: 'Unknown group diagnosis values',
       },
       native: {},
     });
@@ -543,9 +563,72 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
       handler();
     }
 
-    if (activeConfig.length === 0) {
+    this._startUnknownGroupPolling();
+
+    if (activeConfig.length === 0 && !this._isUnknownGroupPollingEnabled()) {
       this.log.debug('No polling requests enabled; skipping scheduled commands');
     }
+  }
+
+  _isUnknownGroupPollingEnabled() {
+    return !!(this.config && this.config.enableUnknownGroupPolling);
+  }
+
+  _getUnknownGroupPollingGroups() {
+    const result = parseUnknownGroupIds(this.config && this.config.unknownGroupIds);
+    this._logUnknownGroupParsingIssues(result);
+    return result.groups;
+  }
+
+  _logUnknownGroupParsingIssues(result) {
+    if (!result) {
+      return;
+    }
+
+    if (result.invalid && result.invalid.length > 0) {
+      this.log.warn(`Ignoring invalid unknown group id(s): ${result.invalid.join(', ')}`);
+    }
+
+    if (result.duplicates && result.duplicates.length > 0) {
+      this.log.debug(
+        `Ignoring duplicate unknown group id(s): ${result.duplicates
+          .map((group) => `0x${formatUnknownGroupId(group)}`)
+          .join(', ')}`
+      );
+    }
+
+    if (result.truncated) {
+      this.log.warn(`Ignoring unknown group ids beyond the limit of ${UNKNOWN_GROUP_MAX_COUNT}`);
+    }
+  }
+
+  _startUnknownGroupPolling() {
+    if (!this._isUnknownGroupPollingEnabled()) {
+      this.log.debug('Unknown group diagnosis polling disabled');
+      return;
+    }
+
+    const groups = this._getUnknownGroupPollingGroups();
+    if (groups.length === 0) {
+      this.log.debug('Unknown group diagnosis polling enabled without valid groups');
+      return;
+    }
+
+    const intervalSeconds = normalizeUnknownGroupPollingInterval(
+      this.config && this.config.unknownGroupPollingInterval,
+      60
+    );
+    const intervalMs = intervalSeconds * 1000;
+    const formattedGroups = groups.map((group) => `0x${formatUnknownGroupId(group)}`).join(', ');
+
+    this.log.debug(
+      `Scheduling unknown group diagnosis polling for ${formattedGroups} every ${intervalSeconds}s`
+    );
+
+    const handler = () => this._pollUnknownGroupsSequentially(groups);
+    const timer = setInterval(handler, intervalMs);
+    this.pollTimers.set('unknownGroups', timer);
+    handler();
   }
 
   _clearPolling() {
@@ -553,6 +636,7 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
       clearInterval(timer);
     }
     this.pollTimers.clear();
+    this._unknownGroupPollingInProgress = false;
   }
 
   _shouldRestartOnError() {
@@ -801,6 +885,25 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
       changed = true;
     }
 
+    const normalizedUnknownGroupPollingInterval = normalizeUnknownGroupPollingInterval(
+      this.config.unknownGroupPollingInterval,
+      60
+    );
+    if (normalizedUnknownGroupPollingInterval !== this.config.unknownGroupPollingInterval) {
+      this.config.unknownGroupPollingInterval = normalizedUnknownGroupPollingInterval;
+      changed = true;
+    }
+
+    const parsedUnknownGroups = parseUnknownGroupIds(this.config.unknownGroupIds);
+    this._logUnknownGroupParsingIssues(parsedUnknownGroups);
+    const normalizedUnknownGroupIds = parsedUnknownGroups.groups
+      .map((group) => formatUnknownGroupId(group))
+      .join(',');
+    if ((this.config.unknownGroupIds || '') !== normalizedUnknownGroupIds) {
+      this.config.unknownGroupIds = normalizedUnknownGroupIds;
+      changed = true;
+    }
+
     const normalizedPollingRequests = normalizePollingRequests(this.config);
     if (!isDeepStrictEqual(this.config.pollingRequests, normalizedPollingRequests)) {
       this.config.pollingRequests = normalizedPollingRequests;
@@ -844,7 +947,13 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
       }
     }
 
-    for (const key of ['modeAsNumber', 'fanSpeedAsNumber', 'swingModeAsNumber', 'restartOnError']) {
+    for (const key of [
+      'modeAsNumber',
+      'fanSpeedAsNumber',
+      'swingModeAsNumber',
+      'restartOnError',
+      'enableUnknownGroupPolling',
+    ]) {
       if (typeof this.config[key] !== 'boolean') {
         const normalized = normalizeBooleanValue(this.config[key]);
         if (normalized !== this.config[key]) {
@@ -993,6 +1102,61 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
     } catch (error) {
       this.log.warn(`Polling group 5 data failed: ${error.message}`);
     }
+  }
+
+  async _pollUnknownGroupsSequentially(groups) {
+    if (!this.bridge || !this.bridge.connected || !Array.isArray(groups) || groups.length === 0) {
+      return;
+    }
+
+    if (this._unknownGroupPollingInProgress) {
+      this.log.debug(
+        'Skipping unknown group diagnosis cycle because the previous cycle is still running'
+      );
+      return;
+    }
+
+    this._unknownGroupPollingInProgress = true;
+
+    try {
+      // Safe diagnosis mode: every request below is a 20-byte C1 query only
+      // (41 21 01 <group> 00 ... 00). No control/set/B0 frames are sent here.
+      for (const groupByte of groups) {
+        if (!this.bridge || !this.bridge.connected) {
+          return;
+        }
+
+        const formattedGroup = `0x${formatUnknownGroupId(groupByte)}`;
+        this.log.debug(`Polling unknown group ${formattedGroup} now`);
+
+        try {
+          const response = await this.bridge.getUnknownGroupData(groupByte);
+          if (response) {
+            this.log.debug(
+              `Unknown group ${formattedGroup} response received: responseId=0x${formatUnknownGroupId(
+                response.responseId
+              )}, groupByte=0x${formatUnknownGroupId(response.groupByte)}, payloadHex=${
+                response.payloadHex || ''
+              }`
+            );
+          } else {
+            this.log.debug(`Unknown group ${formattedGroup} returned no response data`);
+          }
+        } catch (error) {
+          this.log.debug(
+            `Unknown group ${formattedGroup} polling failed: ${this._formatError(error)}`
+          );
+        }
+
+        await this._delay(250);
+      }
+    } finally {
+      this._unknownGroupPollingInProgress = false;
+    }
+  }
+
+  _delay(ms) {
+    return new Promise((resolve) => this.setTimeout(resolve, ms));
   }
 
   _extractStatusEntries(status) {
@@ -1170,6 +1334,82 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
         );
       }
     }
+  }
+
+  async _applyUnknownGroupData(groupData) {
+    if (!groupData || typeof groupData !== 'object') {
+      return;
+    }
+
+    const groupByte = Number.isInteger(groupData.groupByte) ? groupData.groupByte : null;
+    if (groupByte === null) {
+      this.log.debug('Ignoring unknown group response without groupByte');
+      return;
+    }
+
+    const groupId = `group${formatUnknownGroupId(groupByte)}`;
+    this.log.debug(
+      `Applying unknown group ${groupId}: responseId=0x${formatUnknownGroupId(
+        groupData.responseId
+      )}, groupByte=0x${formatUnknownGroupId(groupByte)}, payloadHex=${groupData.payloadHex || ''}`
+    );
+
+    const rawEntries = {
+      rawFrameHex: groupData.rawFrameHex || '',
+      payloadHex: groupData.payloadHex || '',
+      responseId: groupData.responseId,
+      groupByte,
+      rawBytes: groupData.rawBytes || {},
+      analogCandidates: groupData.analogCandidates || {},
+    };
+
+    for (const [key, value] of Object.entries(rawEntries)) {
+      try {
+        const normalized = this._normalizeRawStatusValue(value);
+        if (!normalized) {
+          continue;
+        }
+
+        await this._ensureUnknownGroupRawState(groupId, key, normalized.type, normalized.role);
+        await this.setStateAsync(`statusRaw.unknownGroups.${groupId}.${key}`, {
+          val: normalized.value,
+          ack: true,
+        });
+      } catch (error) {
+        this.log.debug(
+          `Failed to update unknown group ${groupId}.${key}: ${this._formatError(error)}`
+        );
+      }
+    }
+  }
+
+  async _ensureUnknownGroupRawState(groupId, key, type, role) {
+    const stateKey = `${groupId}.${key}`;
+    if (this._knownUnknownGroupRawStates.has(stateKey)) {
+      return;
+    }
+
+    await this.setObjectNotExistsAsync(`statusRaw.unknownGroups.${groupId}`, {
+      type: 'channel',
+      common: {
+        name: `Unknown group ${groupId}`,
+      },
+      native: {},
+    });
+
+    await this.setObjectNotExistsAsync(`statusRaw.unknownGroups.${groupId}.${key}`, {
+      type: 'state',
+      common: {
+        name: key,
+        type,
+        role,
+        read: true,
+        write: false,
+      },
+      native: {},
+    });
+
+    this._knownUnknownGroupRawStates.add(stateKey);
   }
 
   async _ensureRawStatusState(key, type, role) {

--- a/test/polling-config.test.js
+++ b/test/polling-config.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assert = require('assert');
-const { normalizePollingRequests } = require('../lib/polling-config');
+const { normalizePollingRequests, parseUnknownGroupIds } = require('../lib/polling-config');
 
 const DEFAULT_REQUESTS = [
   { id: 'getStatus', enabled: true, interval: 60 },
@@ -96,5 +96,26 @@ assert.deepStrictEqual(
   }).find((entry) => entry.id === 'getPowerUsage'),
   { id: 'getPowerUsage', enabled: true, interval: 300 }
 );
+
+assert.deepStrictEqual(parseUnknownGroupIds('40,41,46').groups, [0x40, 0x41, 0x46]);
+assert.deepStrictEqual(parseUnknownGroupIds('0x40,0x41').groups, [0x40, 0x41]);
+assert.deepStrictEqual(parseUnknownGroupIds('39,40,50,zz,0x4f'), {
+  groups: [0x40, 0x4f],
+  invalid: ['39', '50', 'zz'],
+  duplicates: [],
+  truncated: false,
+});
+assert.deepStrictEqual(parseUnknownGroupIds('40,0x40,41,41'), {
+  groups: [0x40, 0x41],
+  invalid: [],
+  duplicates: [0x40, 0x41],
+  truncated: false,
+});
+assert.deepStrictEqual(parseUnknownGroupIds('40,41,42,43,44,45,46,47,48,49'), {
+  groups: [0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47],
+  invalid: [],
+  duplicates: [],
+  truncated: true,
+});
 
 console.log('polling config normalization tests passed');


### PR DESCRIPTION
### Motivation

- Provide a safe, read-only diagnosis mode to probe undocumented C1 group bytes (0x40–0x4F) without sending any control/set frames.  
- Allow operators to explore additional group responses (temperatures, pressures, frequencies, EEV, fan speeds, protection flags) while avoiding device state changes.  
- Validate and limit user input to prevent flooding and unsafe usage (min interval, max groups, ignore invalid/duplicate entries).

### Description

- Added admin/native configuration: `enableUnknownGroupPolling` (bool), `unknownGroupPollingInterval` (number, min 10s), and `unknownGroupIds` (text) and documented usage in `README.md` and `admin/jsonConfig.json`/`io-package.json`.  
- Implemented robust parsing/validation in `lib/polling-config.js` (`parseUnknownGroupIds`, token extraction, normalization, limits, formatting helpers) and exported helpers used by the adapter.  
- Implemented safe 20-byte C1 query creation and raw response helper in the vendored `node-mideahvac` code (`lib/node-mideahvac/lib/ac.js` and `lib/node-mideahvac/lib/serialbridge.js`) plus a read-only bridge API `getUnknownGroupData` in `lib/midea-serial-bridge.js` that emits `unknownGroupData`.  
- Integrated sequential, rate-limited polling and raw-only state storage in `main.js`: scheduled unknown-group cycles (sequential with 250ms gap), in-progress guard to avoid overlapping cycles, normalized config persistence, and creation of analysis-only states under `statusRaw.unknownGroups.groupXX.*` (`rawFrameHex`, `payloadHex`, `responseId`, `groupByte`, `rawBytes`, `analogCandidates`).  

### Testing

- Added unit tests for unknown-group parsing in `test/polling-config.test.js` covering `"40,41,46"`, `"0x40,0x41"`, invalid tokens, duplicates and truncation beyond 8 groups; these tests pass.  
- Ran the full test suite with `npm test` which executed `test/raw-parser-helper.test.js`, `test/c1-parser.test.js` and `test/polling-config.test.js`; all tests passed.  
- Linting (`eslint .`) completed as part of the test script with no blocking errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26a76c1de8832596162c624ce99e34)