### PR TITLE
Expose Group 41 raw hex diagnostics and expand unknown-group diagnosis range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## **WORK IN PROGRESS**
 
+- expose Group 41 raw frame/payload hex values and update compact raw hex output with Group 41 frames
+- expand safe unknown-group diagnosis polling to optional group bytes 0x30-0x5F with up to 16 sequential groups
+
 - add optional automatic adapter restart on connection errors with configurable delay
 - remove raw byte and analog candidate analysis states; keep only compact raw hex debug output
 

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -173,8 +173,8 @@
           },
           "default": false,
           "help": {
-            "en": "Sends only safe 20-byte C1 query frames (41 21 01 <group> 00 ... 00) for configured group bytes.",
-            "de": "Sendet ausschließlich sichere 20-Byte-C1-Query-Frames (41 21 01 <group> 00 ... 00) für konfigurierte Gruppenbytes."
+            "en": "Experimental diagnosis mode. Only Midea query groups 0x30-0x5F. No control commands. Sends only safe 20-byte C1 query frames (41 21 01 <group> 00 ... 00).",
+            "de": "Experimenteller Diagnosemodus. Nur Midea-Query-Gruppen 0x30-0x5F. Keine Steuerbefehle. Sendet ausschließlich sichere 20-Byte-C1-Query-Frames (41 21 01 <group> 00 ... 00)."
           },
           "xs": 12,
           "sm": 6,
@@ -209,10 +209,10 @@
             "de": "Unbekannte Gruppen-IDs"
           },
           "default": "",
-          "placeholder": "40,41,42,43,46,47,48,49",
+          "placeholder": "30,31,40,46,50,5F",
           "help": {
-            "en": "Comma-separated hex group bytes from 0x40 to 0x4F. At most 8 values are used; duplicates and invalid values are ignored.",
-            "de": "Kommagetrennte Hex-Gruppenbytes von 0x40 bis 0x4F. Maximal 8 Werte werden genutzt; doppelte und ungültige Werte werden ignoriert."
+            "en": "Comma-separated hex group bytes from 0x30 to 0x5F. At most 16 values are used sequentially; supported groups 0x41, 0x44, and 0x45 are skipped.",
+            "de": "Kommagetrennte Hex-Gruppenbytes von 0x30 bis 0x5F. Maximal 16 Werte werden nacheinander genutzt; unterstützte Gruppen 0x41, 0x44 und 0x45 werden übersprungen."
           },
           "xs": 12,
           "sm": 12,

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "name": "midea-serialbridge",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "titleLang": {
       "en": "Midea Serial Bridge",
       "de": "Midea Serial Bridge",
@@ -55,6 +55,10 @@
       "type": "open-source"
     },
     "news": {
+      "0.0.7": {
+        "en": "Expose Group 41 raw hex debug states and broaden safe unknown-group diagnosis polling.",
+        "de": "Ergänzt Group-41-Rohhex-Debugzustände und erweitert die sichere Diagnoseabfrage unbekannter Gruppen."
+      },
       "0.0.6": {
         "en": "Keep raw debug output compact and remove raw byte/analog analysis states.",
         "de": "Kompakte Rohdebug-Ausgabe beibehalten und Rohbyte-/Analog-Analysezustände entfernen."

--- a/lib/node-mideahvac/lib/ac.js
+++ b/lib/node-mideahvac/lib/ac.js
@@ -21,8 +21,8 @@ function createGroupDataCommand(group) {
 }
 
 function createGroupDataCommandByByte(groupByte) {
-  if (!Number.isInteger(groupByte) || groupByte < 0x40 || groupByte > 0x4f) {
-    throw new errors.OutOfRangeError('Group byte must be between 0x40 and 0x4F');
+  if (!Number.isInteger(groupByte) || groupByte < 0x30 || groupByte > 0x5f) {
+    throw new errors.OutOfRangeError('Group byte must be between 0x30 and 0x5F');
   }
 
   // Safe diagnosis mode: this creates only the known 20-byte C1 query frame

--- a/lib/polling-config.js
+++ b/lib/polling-config.js
@@ -30,9 +30,9 @@ const POLLING_METHODS = [
 
 const POLLING_METHOD_MAP = new Map(POLLING_METHODS.map((entry) => [entry.id, entry]));
 
-const UNKNOWN_GROUP_MIN = 0x40;
-const UNKNOWN_GROUP_MAX = 0x4f;
-const UNKNOWN_GROUP_MAX_COUNT = 8;
+const UNKNOWN_GROUP_MIN = 0x30;
+const UNKNOWN_GROUP_MAX = 0x5f;
+const UNKNOWN_GROUP_MAX_COUNT = 16;
 const UNKNOWN_GROUP_MIN_INTERVAL = 10;
 
 function normalizeUnknownGroupPollingInterval(value, fallback = 60) {

--- a/main.js
+++ b/main.js
@@ -1125,7 +1125,7 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
       return;
     }
 
-    this.log.debug('Polling group 41 diagnostic data now');
+    this.log.debug('Polling group 41 data now');
 
     try {
       await this.bridge.getGroup41Data();
@@ -1157,9 +1157,9 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
         }
 
         const formattedGroup = `0x${formatUnknownGroupId(groupByte)}`;
-        if (groupByte === 0x41) {
+        if ([0x41, 0x44, 0x45].includes(groupByte)) {
           this.log.debug(
-            'Group 41 is supported as getGroup41Data; skipping unknown group diagnosis polling for 0x41'
+            `Group ${formatUnknownGroupId(groupByte)} is already supported; skipping unknown group diagnosis polling for ${formattedGroup}`
           );
           continue;
         }
@@ -1415,8 +1415,17 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
       return;
     }
 
+    this.log.debug(
+      `Received group 41 payload: ${group41Data.group41_payloadHex || group41Data.payloadHex || ''}`
+    );
+    this.log.debug(
+      `Decoded group 41 diagnostic data: compressorFrequencyCandidate=${group41Data.compressorFrequencyCandidate}, hotGasOrCondenserTemperatureCandidate=${group41Data.hotGasOrCondenserTemperatureCandidate}, evaporatorTemperature1Candidate=${group41Data.evaporatorTemperature1Candidate}, evaporatorTemperature2Candidate=${group41Data.evaporatorTemperature2Candidate}, outdoorCoilTemperatureCandidate=${group41Data.outdoorCoilTemperatureCandidate}, outdoorAmbientTemperatureCandidate=${group41Data.outdoorAmbientTemperatureCandidate}`
+    );
+
     if (this.config && this.config.exposeRawStatus) {
       const rawEntries = Object.entries({
+        rawFrameHex: group41Data.rawFrameHex || group41Data.group41_rawFrameHex || '',
+        payloadHex: group41Data.payloadHex || group41Data.group41_payloadHex || '',
         group41_rawFrameHex: group41Data.group41_rawFrameHex || group41Data.rawFrameHex || '',
         group41_payloadHex: group41Data.group41_payloadHex || group41Data.payloadHex || '',
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iobroker.midea-serialbridge",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iobroker.midea-serialbridge",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "@iobroker/adapter-core": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.midea-serialbridge",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "ioBroker adapter for controlling Midea climate devices via serial bridge",
   "author": {
     "name": "dosordie"

--- a/test/polling-config.test.js
+++ b/test/polling-config.test.js
@@ -110,9 +110,9 @@ assert.deepStrictEqual(
 
 assert.deepStrictEqual(parseUnknownGroupIds('40,41,46').groups, [0x40, 0x41, 0x46]);
 assert.deepStrictEqual(parseUnknownGroupIds('0x40,0x41').groups, [0x40, 0x41]);
-assert.deepStrictEqual(parseUnknownGroupIds('39,40,50,zz,0x4f'), {
-  groups: [0x40, 0x4f],
-  invalid: ['39', '50', 'zz'],
+assert.deepStrictEqual(parseUnknownGroupIds('29,30,40,50,60,zz,0x5f'), {
+  groups: [0x30, 0x40, 0x50, 0x5f],
+  invalid: ['29', '60', 'zz'],
   duplicates: [],
   truncated: false,
 });
@@ -122,8 +122,10 @@ assert.deepStrictEqual(parseUnknownGroupIds('40,0x40,41,41'), {
   duplicates: [0x40, 0x41],
   truncated: false,
 });
-assert.deepStrictEqual(parseUnknownGroupIds('40,41,42,43,44,45,46,47,48,49'), {
-  groups: [0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47],
+assert.deepStrictEqual(parseUnknownGroupIds('30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46'), {
+  groups: [
+    0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x40, 0x41, 0x42, 0x43, 0x44, 0x45,
+  ],
   invalid: [],
   duplicates: [],
   truncated: true,


### PR DESCRIPTION
### Motivation
- Provide compact raw hex debug for every successful C1 Group-41 response while keeping existing sensor decoding and without reintroducing raw byte / analog-candidate states. 
- Broaden the safe unknown-group diagnosis mode so experimenters can probe more group bytes while keeping the mode read-only and safe.

### Description
- Write Group-41 raw debug into `statusRaw.group41_rawFrameHex` and `statusRaw.group41_payloadHex` and also update `statusRaw.rawFrameHex` / `statusRaw.payloadHex` with the last received Group-41 frame when `exposeRawStatus` is enabled; existing decoded `sensors.*` mapping is unchanged. 
- Add debug messages around Group-41 polling: `Polling group 41 data now`, `Received group 41 payload: ...` and `Decoded group 41 diagnostic data: ...` for easier tracing. 
- Expand unknown-group diagnosis range from `0x40–0x4F` to `0x30–0x5F`, increase max sequential groups to 16, keep minimum interval 10s, maintain sequential (non-parallel) sending, and continue to restrict frames to safe 20-byte C1 query format (`41 21 01 <group> 00 ... 00`). 
- Skip already-supported groups (`0x41`, `0x44`, `0x45`) in unknown-group polling and keep the adapter strictly read-only in this mode (no control/set/B0 frames). 
- Update admin UI/help text, tests and version to `0.0.7`, and add a short news entry and changelog note.

### Testing
- Ran the automated test suite via `npm test` which runs `node test/raw-parser-helper.test.js`, `node test/c1-parser.test.js`, `node test/polling-config.test.js` and `eslint .`; all parser and polling-config tests passed and linting completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26bcc6c77c83258f9a3ba1cf34c13c)