### PR TITLE
Refine Group 41 diagnostics and extend unknown-group polling (0.0.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## **WORK IN PROGRESS**
 
-- refine C1 Group 41 diagnostic sensor names, byte mappings and temperature scaling from new logs
-- expose Group 41 raw frame/payload hex values and update compact raw hex output with Group 41 frames
-- expand safe unknown-group diagnosis polling to optional group bytes 0x30-0x5F with up to 16 sequential groups
+## 0.0.9 (2026-06-08)
+
+- extend safe unknown-group diagnosis polling to optional group bytes 0x20-0x7F with up to 16 sequential groups while skipping regular groups 0x41, 0x44 and 0x45
+- rename C1 Group 41 diagnostic datapoints for confirmed compressor, indoor pipe, indoor heat exchanger and outdoor-temperature meanings
+- expose C1 Group 41 byte 08 neutrally as raw value plus one temperature candidate and keep byte 12 marked as an outdoor heat-exchanger temperature candidate
+- delete legacy Group 41 candidate sensor states on startup and keep raw debug output compact without rawByte/analogCandidates mass states
+
+## 0.0.8 (2026-06-08)
 
 - add optional automatic adapter restart on connection errors with configurable delay
 - remove raw byte and analog candidate analysis states; keep only compact raw hex debug output

--- a/README.md
+++ b/README.md
@@ -31,37 +31,38 @@ Open the adapter configuration in the ioBroker Admin. Enter the IP address (or h
 
 For protocol analysis you can enable **Enable unknown group diagnosis polling** on the **Options** tab. This mode is intentionally read-only: it sends only safe 20-byte C1 query frames in the known `41 21 01 <group> 00 ... 00` schema and does not send control, SetStatus or B0 property-set frames.
 
-Configure **Unknown group IDs** as comma-separated hexadecimal group bytes from `0x40` to `0x4F`, for example `40,41,42,43,46,47,48,49`. The adapter ignores invalid values and duplicates, enforces a minimum interval of 10 seconds, limits the list to 8 groups, and polls the groups sequentially with a small pause so the device is not flooded.
+Configure **Unknown group IDs** as comma-separated hexadecimal group bytes from `0x20` to `0x7F`, for example `20,21,30,31,50,51,60,7F`. The adapter ignores invalid values and duplicates, enforces a minimum interval of 10 seconds, limits the list to 16 groups, and polls the groups sequentially with a small pause so the device is not flooded. Regularly supported groups (`0x41` / `getGroup41Data`, `0x44` / power usage, `0x45` / Group 5 data) are skipped in this mode with a debug note.
 
-Responses are written only below `statusRaw.unknownGroups.groupXX.*` for analysis and never create normal sensor datapoints. Each response includes only compact metadata: `rawFrameHex`, `payloadHex`, `responseId` and `groupByte`. Group byte `0x41` is now supported as `getGroup41Data`; if it is still configured here, the adapter skips it with a debug note instead of creating duplicate unknown-group states. Compare `payloadHex` while changing real-world conditions to identify frame-level differences.
+Responses are written only below `statusRaw.unknownGroups.groupXX.*` for analysis and never create normal sensor datapoints. Each response includes only compact raw hex states: `rawFrameHex` and `payloadHex`. The mode intentionally does not create `rawByteXX`, `rawByteXXBits` or `analogCandidates` mass states. Compare `payloadHex` while changing real-world conditions to identify frame-level differences.
 
 ### C1 Group 41 diagnostic data
 
 The regular polling configuration includes `getGroup41Data`, a read-only 20-byte C1 query (`41 21 01 41 00 ... 00`) for Group 41 diagnostic data. The decoded values are exposed as normal `sensors.*` datapoints. Some Group 41 values are still experimental and can differ between Midea devices, so uncertain values keep `Candidate` / `Kandidat` in their state IDs, names and descriptions.
 
-Group 41 currently exposes the confirmed compressor frequency, indoor pipe temperature, indoor heat exchanger temperature and Group 41 outdoor temperature. It also exposes two still-experimental candidate values for outdoor-unit / condenser / pipe temperatures. Byte 10 and byte 11 use the `raw - 50` scaling found in newer logs; byte 08, byte 12 and byte 13 continue to use `(byte - 50) / 2`. When raw status output is enabled, compact Group 41 raw values remain available as `statusRaw.group41_rawFrameHex` and `statusRaw.group41_payloadHex`.
+Group 41 currently exposes the confirmed compressor frequency, indoor pipe temperature, indoor heat exchanger temperature and Group 41 outdoor temperature. Byte 08 remains unclear and is therefore exposed neutrally as a raw value plus one temperature candidate. Byte 12 remains a candidate for an outdoor-unit / condenser / heat-exchanger temperature. Byte 10 and byte 11 use the `raw - 50` scaling found in newer logs; byte 08, byte 12 and byte 13 use `(byte - 50) / 2` for the temperature values. When raw status output is enabled, compact Group 41 raw values remain available as `statusRaw.group41_rawFrameHex` and `statusRaw.group41_payloadHex`.
 
 The following datapoints are available out of the box:
 
-| State ID                          | Description                                                                                   | Read | Write |
-| --------------------------------- | --------------------------------------------------------------------------------------------- | ---- | ----- |
-| `power`                           | Turn the unit on or off                                                                       | ✓    | ✓     |
-| `mode`                            | Operation mode (auto, cool, heat, dry, fan)                                                   | ✓    | ✓     |
-| `targetTemperature`               | Desired room temperature                                                                      | ✓    | ✓     |
-| `indoorTemperature`               | Current indoor temperature                                                                    | ✓    | ✗     |
-| `outdoorTemperature`              | Current outdoor temperature                                                                   | ✓    | ✗     |
-| `totalEnergy`                     | Internal total energy counter from C1 group 4 (kWh)                                           | ✓    | ✗     |
-| `compressorFrequency`             | Compressor frequency from C1 Group 41 byte 04 (Hz)                                            | ✓    | ✗     |
-| `outdoorPipeTemperatureCandidate` | Candidate outdoor-unit, condenser or pipe temperature from C1 Group 41 byte 08 (°C)           | ✓    | ✗     |
-| `indoorPipeTemperature`           | Indoor pipe / air temperature from C1 Group 41 byte 10 (°C)                                   | ✓    | ✗     |
-| `indoorHeatExchangerTemperature`  | Indoor heat exchanger / pipe temperature from C1 Group 41 byte 11 (°C)                        | ✓    | ✗     |
-| `outdoorCoilTemperatureCandidate` | Candidate outdoor-unit, condenser or heat exchanger temperature from C1 Group 41 byte 12 (°C) | ✓    | ✗     |
-| `outdoorTemperatureGroup41`       | Outdoor temperature from C1 Group 41 byte 13 (°C)                                             | ✓    | ✗     |
-| `fanSpeed`                        | Fan speed (auto, low, medium, high)                                                           | ✓    | ✓     |
-| `swingMode`                       | Swing mode (off, vertical, horizontal, both)                                                  | ✓    | ✓     |
-| `ecoMode`                         | Eco mode                                                                                      | ✓    | ✓     |
-| `turboMode`                       | Turbo / powerful mode                                                                         | ✓    | ✓     |
-| `sleepMode`                       | Sleep mode                                                                                    | ✓    | ✓     |
+| State ID                                   | Description                                                                                   | Read | Write |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------- | ---- | ----- |
+| `power`                                    | Turn the unit on or off                                                                       | ✓    | ✓     |
+| `mode`                                     | Operation mode (auto, cool, heat, dry, fan)                                                   | ✓    | ✓     |
+| `targetTemperature`                        | Desired room temperature                                                                      | ✓    | ✓     |
+| `indoorTemperature`                        | Current indoor temperature                                                                    | ✓    | ✗     |
+| `outdoorTemperature`                       | Current outdoor temperature                                                                   | ✓    | ✗     |
+| `totalEnergy`                              | Internal total energy counter from C1 group 4 (kWh)                                           | ✓    | ✗     |
+| `compressorFrequency`                      | Compressor frequency from C1 Group 41 byte 04 (Hz)                                            | ✓    | ✗     |
+| `group41Byte08Raw`                         | Neutral raw value from C1 Group 41 byte 08                                                    | ✓    | ✗     |
+| `group41Byte08TemperatureCandidate`        | Candidate unknown temperature value from C1 Group 41 byte 08 using `(raw - 50) / 2` (°C)      | ✓    | ✗     |
+| `indoorPipeTemperature`                    | Indoor pipe / air temperature from C1 Group 41 byte 10 (°C)                                   | ✓    | ✗     |
+| `indoorHeatExchangerTemperature`           | Indoor heat exchanger / pipe temperature from C1 Group 41 byte 11 (°C)                        | ✓    | ✗     |
+| `outdoorHeatExchangerTemperatureCandidate` | Candidate outdoor-unit, condenser or heat exchanger temperature from C1 Group 41 byte 12 (°C) | ✓    | ✗     |
+| `outdoorTemperatureGroup41`                | Outdoor temperature from C1 Group 41 byte 13 (°C)                                             | ✓    | ✗     |
+| `fanSpeed`                                 | Fan speed (auto, low, medium, high)                                                           | ✓    | ✓     |
+| `swingMode`                                | Swing mode (off, vertical, horizontal, both)                                                  | ✓    | ✓     |
+| `ecoMode`                                  | Eco mode                                                                                      | ✓    | ✓     |
+| `turboMode`                                | Turbo / powerful mode                                                                         | ✓    | ✓     |
+| `sleepMode`                                | Sleep mode                                                                                    | ✓    | ✓     |
 
 Whenever you change a writable state in ioBroker the adapter forwards the command to the bridge immediately.
 

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -173,8 +173,8 @@
           },
           "default": false,
           "help": {
-            "en": "Experimental diagnosis mode. Only Midea query groups 0x30-0x5F. No control commands. Sends only safe 20-byte C1 query frames (41 21 01 <group> 00 ... 00).",
-            "de": "Experimenteller Diagnosemodus. Nur Midea-Query-Gruppen 0x30-0x5F. Keine Steuerbefehle. Sendet ausschließlich sichere 20-Byte-C1-Query-Frames (41 21 01 <group> 00 ... 00)."
+            "en": "Experimental diagnosis mode. Only Midea query groups 0x20-0x7F. No control commands. Sends only safe 20-byte C1 query frames (41 21 01 <group> 00 ... 00).",
+            "de": "Experimenteller Diagnosemodus. Nur Midea-Query-Gruppen 0x20-0x7F. Keine Steuerbefehle. Sendet ausschließlich sichere 20-Byte-C1-Query-Frames (41 21 01 <group> 00 ... 00)."
           },
           "xs": 12,
           "sm": 6,
@@ -209,10 +209,10 @@
             "de": "Unbekannte Gruppen-IDs"
           },
           "default": "",
-          "placeholder": "30,31,40,46,50,5F",
+          "placeholder": "20,21,30,31,50,51,60,7F",
           "help": {
-            "en": "Comma-separated hex group bytes from 0x30 to 0x5F. At most 16 values are used sequentially; supported groups 0x41, 0x44, and 0x45 are skipped.",
-            "de": "Kommagetrennte Hex-Gruppenbytes von 0x30 bis 0x5F. Maximal 16 Werte werden nacheinander genutzt; unterstützte Gruppen 0x41, 0x44 und 0x45 werden übersprungen."
+            "en": "Comma-separated hex group bytes from 0x20 to 0x7F. At most 16 values are used sequentially; supported groups 0x41, 0x44, and 0x45 are skipped.",
+            "de": "Kommagetrennte Hex-Gruppenbytes von 0x20 bis 0x7F. Maximal 16 Werte werden nacheinander genutzt; unterstützte Gruppen 0x41, 0x44 und 0x45 werden übersprungen."
           },
           "xs": 12,
           "sm": 12,

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "name": "midea-serialbridge",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "titleLang": {
       "en": "Midea Serial Bridge",
       "de": "Midea Serial Bridge",
@@ -55,6 +55,10 @@
       "type": "open-source"
     },
     "news": {
+      "0.0.9": {
+        "en": "Extend safe unknown-group diagnosis to 0x20-0x7F and neutralize Group 41 byte 08 output.",
+        "de": "Erweitert die sichere Unknown-Group-Diagnose auf 0x20-0x7F und gibt Group-41 Byte 08 neutraler aus."
+      },
       "0.0.8": {
         "en": "Refine C1 Group 41 diagnostic sensor names and scaling from new logs.",
         "de": "Verfeinert C1-Group-41-Diagnosesensoren, Benennungen und Skalierung anhand neuer Logs."

--- a/lib/datapoints.js
+++ b/lib/datapoints.js
@@ -236,13 +236,25 @@ const DATA_POINTS = [
     readOnly: true,
   },
   {
-    id: 'outdoorPipeTemperatureCandidate',
+    id: 'group41Byte08Raw',
     channel: 'sensors',
     name: {
-      en: 'Outdoor pipe temperature candidate',
-      de: 'Außengerät-Rohrtemperatur Kandidat',
+      en: 'Group 41 byte 08 raw value',
+      de: 'Group-41 Byte 08 Rohwert',
     },
-    desc: 'Kandidat: Außengerät-, Kondensator- oder Rohrtemperatur aus C1 Group 41 Byte 08. Bedeutung noch nicht endgültig bestätigt.',
+    desc: 'Rohwert aus C1 Group 41 Byte 08. Bedeutung unklar; möglicher interner Analog-, Temperatur-, ADC- oder Statuswert.',
+    role: 'value',
+    type: 'number',
+    readOnly: true,
+  },
+  {
+    id: 'group41Byte08TemperatureCandidate',
+    channel: 'sensors',
+    name: {
+      en: 'Group 41 temperature 1 candidate',
+      de: 'Group-41 Temperatur 1 Kandidat',
+    },
+    desc: 'Kandidat: unbekannter Temperaturwert aus C1 Group 41 Byte 08. Die Bedeutung ist unklar; alternative Skalierung raw - 100 ist ebenfalls möglich. Nicht als Druck, EEV oder Heißgas bestätigt.',
     role: 'value.temperature',
     type: 'number',
     unit: '°C',
@@ -275,7 +287,7 @@ const DATA_POINTS = [
     readOnly: true,
   },
   {
-    id: 'outdoorCoilTemperatureCandidate',
+    id: 'outdoorHeatExchangerTemperatureCandidate',
     channel: 'sensors',
     name: {
       en: 'Outdoor heat exchanger temperature candidate',

--- a/lib/node-mideahvac/lib/ac.js
+++ b/lib/node-mideahvac/lib/ac.js
@@ -21,8 +21,8 @@ function createGroupDataCommand(group) {
 }
 
 function createGroupDataCommandByByte(groupByte) {
-  if (!Number.isInteger(groupByte) || groupByte < 0x30 || groupByte > 0x5f) {
-    throw new errors.OutOfRangeError('Group byte must be between 0x30 and 0x5F');
+  if (!Number.isInteger(groupByte) || groupByte < 0x20 || groupByte > 0x7f) {
+    throw new errors.OutOfRangeError('Group byte must be between 0x20 and 0x7F');
   }
 
   // Safe diagnosis mode: this creates only the known 20-byte C1 query frame

--- a/lib/node-mideahvac/lib/parsers/C1.js
+++ b/lib/node-mideahvac/lib/parsers/C1.js
@@ -98,15 +98,16 @@ function parseGroup41(data) {
 
   const status = {
     compressorFrequency: data[4],
-    outdoorPipeTemperatureCandidate: decodeMideaTemperature(data[8]),
+    group41Byte08Raw: data[8],
+    group41Byte08TemperatureCandidate: decodeMideaTemperature(data[8]),
     indoorPipeTemperature: decodeGroup41IndoorTemperature(data[10]),
     indoorHeatExchangerTemperature: decodeGroup41IndoorTemperature(data[11]),
-    outdoorCoilTemperatureCandidate: decodeMideaTemperature(data[12]),
+    outdoorHeatExchangerTemperatureCandidate: decodeMideaTemperature(data[12]),
     outdoorTemperatureGroup41: decodeMideaTemperature(data[13]),
   };
 
   logger.debug(
-    `C1.parser: Decoded group 41 diagnostic data: compressorFrequency=${status.compressorFrequency}, outdoorPipeTemperatureCandidate=${status.outdoorPipeTemperatureCandidate}, indoorPipeTemperature=${status.indoorPipeTemperature}, indoorHeatExchangerTemperature=${status.indoorHeatExchangerTemperature}, outdoorCoilTemperatureCandidate=${status.outdoorCoilTemperatureCandidate}, outdoorTemperatureGroup41=${status.outdoorTemperatureGroup41}`
+    `C1.parser: Decoded group 41 diagnostic data: compressorFrequency=${status.compressorFrequency}, group41Byte08Raw=${status.group41Byte08Raw}, group41Byte08TemperatureCandidate=${status.group41Byte08TemperatureCandidate}, indoorPipeTemperature=${status.indoorPipeTemperature}, indoorHeatExchangerTemperature=${status.indoorHeatExchangerTemperature}, outdoorHeatExchangerTemperatureCandidate=${status.outdoorHeatExchangerTemperatureCandidate}, outdoorTemperatureGroup41=${status.outdoorTemperatureGroup41}`
   );
 
   return status;

--- a/lib/polling-config.js
+++ b/lib/polling-config.js
@@ -30,10 +30,15 @@ const POLLING_METHODS = [
 
 const POLLING_METHOD_MAP = new Map(POLLING_METHODS.map((entry) => [entry.id, entry]));
 
-const UNKNOWN_GROUP_MIN = 0x30;
-const UNKNOWN_GROUP_MAX = 0x5f;
+const UNKNOWN_GROUP_MIN = 0x20;
+const UNKNOWN_GROUP_MAX = 0x7f;
 const UNKNOWN_GROUP_MAX_COUNT = 16;
 const UNKNOWN_GROUP_MIN_INTERVAL = 10;
+const REGULAR_GROUP_BYTES = new Map([
+  [0x41, 'getGroup41Data'],
+  [0x44, 'getPowerUsage'],
+  [0x45, 'getGroup5Data'],
+]);
 
 function normalizeUnknownGroupPollingInterval(value, fallback = 60) {
   const numericValue = Number(value);
@@ -106,6 +111,7 @@ function parseUnknownGroupIds(value, options = {}) {
   const groups = [];
   const invalid = [];
   const duplicates = [];
+  const skippedRegular = [];
   const seen = new Set();
   let truncated = false;
 
@@ -121,16 +127,22 @@ function parseUnknownGroupIds(value, options = {}) {
       continue;
     }
 
+    seen.add(parsed);
+
+    if (REGULAR_GROUP_BYTES.has(parsed)) {
+      skippedRegular.push(parsed);
+      continue;
+    }
+
     if (groups.length >= maxGroups) {
       truncated = true;
       continue;
     }
 
-    seen.add(parsed);
     groups.push(parsed);
   }
 
-  return { groups, invalid, duplicates, truncated };
+  return { groups, invalid, duplicates, skippedRegular, truncated };
 }
 
 function formatUnknownGroupId(groupByte) {
@@ -237,6 +249,7 @@ module.exports = {
   UNKNOWN_GROUP_MAX_COUNT,
   UNKNOWN_GROUP_MIN,
   UNKNOWN_GROUP_MIN_INTERVAL,
+  REGULAR_GROUP_BYTES,
   describePollingEntries,
   formatUnknownGroupId,
   normalizeBooleanValue,

--- a/main.js
+++ b/main.js
@@ -604,6 +604,16 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
       );
     }
 
+    if (result.skippedRegular && result.skippedRegular.length > 0) {
+      for (const group of result.skippedRegular) {
+        this.log.debug(
+          `Skipping unknown group 0x${formatUnknownGroupId(
+            group
+          )} because it is supported as regular group`
+        );
+      }
+    }
+
     if (result.truncated) {
       this.log.warn(`Ignoring unknown group ids beyond the limit of ${UNKNOWN_GROUP_MAX_COUNT}`);
     }
@@ -1158,13 +1168,6 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
         }
 
         const formattedGroup = `0x${formatUnknownGroupId(groupByte)}`;
-        if ([0x41, 0x44, 0x45].includes(groupByte)) {
-          this.log.debug(
-            `Group ${formatUnknownGroupId(groupByte)} is already supported; skipping unknown group diagnosis polling for ${formattedGroup}`
-          );
-          continue;
-        }
-
         this.log.debug(`Polling unknown group ${formattedGroup} now`);
 
         try {
@@ -1220,8 +1223,10 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
     const legacyGroup41CandidateStates = [
       'sensors.compressorFrequencyCandidate',
       'sensors.hotGasOrCondenserTemperatureCandidate',
+      'sensors.outdoorPipeTemperatureCandidate',
       'sensors.evaporatorTemperature1Candidate',
       'sensors.evaporatorTemperature2Candidate',
+      'sensors.outdoorCoilTemperatureCandidate',
       'sensors.outdoorAmbientTemperatureCandidate',
     ];
 
@@ -1445,7 +1450,7 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
       `Received group 41 payload: ${group41Data.group41_payloadHex || group41Data.payloadHex || ''}`
     );
     this.log.debug(
-      `Decoded group 41 diagnostic data: compressorFrequency=${group41Data.compressorFrequency}, outdoorPipeTemperatureCandidate=${group41Data.outdoorPipeTemperatureCandidate}, indoorPipeTemperature=${group41Data.indoorPipeTemperature}, indoorHeatExchangerTemperature=${group41Data.indoorHeatExchangerTemperature}, outdoorCoilTemperatureCandidate=${group41Data.outdoorCoilTemperatureCandidate}, outdoorTemperatureGroup41=${group41Data.outdoorTemperatureGroup41}`
+      `Decoded group 41 diagnostic data: compressorFrequency=${group41Data.compressorFrequency}, group41Byte08Raw=${group41Data.group41Byte08Raw}, group41Byte08TemperatureCandidate=${group41Data.group41Byte08TemperatureCandidate}, indoorPipeTemperature=${group41Data.indoorPipeTemperature}, indoorHeatExchangerTemperature=${group41Data.indoorHeatExchangerTemperature}, outdoorHeatExchangerTemperatureCandidate=${group41Data.outdoorHeatExchangerTemperatureCandidate}, outdoorTemperatureGroup41=${group41Data.outdoorTemperatureGroup41}`
     );
 
     if (this.config && this.config.exposeRawStatus) {
@@ -1460,10 +1465,12 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
 
     const mapped = {
       compressorFrequency: group41Data.compressorFrequency,
-      outdoorPipeTemperatureCandidate: group41Data.outdoorPipeTemperatureCandidate,
+      group41Byte08Raw: group41Data.group41Byte08Raw,
+      group41Byte08TemperatureCandidate: group41Data.group41Byte08TemperatureCandidate,
       indoorPipeTemperature: group41Data.indoorPipeTemperature,
       indoorHeatExchangerTemperature: group41Data.indoorHeatExchangerTemperature,
-      outdoorCoilTemperatureCandidate: group41Data.outdoorCoilTemperatureCandidate,
+      outdoorHeatExchangerTemperatureCandidate:
+        group41Data.outdoorHeatExchangerTemperatureCandidate,
       outdoorTemperatureGroup41: group41Data.outdoorTemperatureGroup41,
     };
 
@@ -1508,8 +1515,6 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
     const rawEntries = {
       rawFrameHex: groupData.rawFrameHex || '',
       payloadHex: groupData.payloadHex || '',
-      responseId: groupData.responseId,
-      groupByte,
     };
 
     for (const [key, value] of Object.entries(rawEntries)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iobroker.midea-serialbridge",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iobroker.midea-serialbridge",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "MIT",
       "dependencies": {
         "@iobroker/adapter-core": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.midea-serialbridge",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "ioBroker adapter for controlling Midea climate devices via serial bridge",
   "author": {
     "name": "dosordie"

--- a/test/c1-parser.test.js
+++ b/test/c1-parser.test.js
@@ -59,29 +59,35 @@ assert.strictEqual(parser(shortGroup5).group, 5);
 
 const group41FanOnly = parser(Buffer.from('c12101410000000094054949656b000000000000', 'hex'));
 assert.strictEqual(group41FanOnly.compressorFrequency, 0);
-assert.strictEqual(group41FanOnly.outdoorPipeTemperatureCandidate, 49.0);
+assert.strictEqual(group41FanOnly.group41Byte08Raw, 148);
+assert.strictEqual(group41FanOnly.group41Byte08TemperatureCandidate, 49.0);
 assert.strictEqual(group41FanOnly.indoorPipeTemperature, 23);
 assert.strictEqual(group41FanOnly.indoorHeatExchangerTemperature, 23);
-assert.strictEqual(group41FanOnly.outdoorCoilTemperatureCandidate, 25.5);
+assert.strictEqual(group41FanOnly.outdoorHeatExchangerTemperatureCandidate, 25.5);
 assert.strictEqual(group41FanOnly.outdoorTemperatureGroup41, 28.5);
 assert.strictEqual(group41FanOnly.group41_payloadHex, 'c12101410000000094054949656b000000000000');
 assert.strictEqual(group41FanOnly.rawBytes, undefined);
 assert.strictEqual(group41FanOnly.analogCandidates, undefined);
+assert.strictEqual(group41FanOnly.outdoorPipeTemperatureCandidate, undefined);
+assert.strictEqual(group41FanOnly.hotGasOrCondenserTemperatureCandidate, undefined);
+assert.strictEqual(group41FanOnly.outdoorCoilTemperatureCandidate, undefined);
 
 const group41Cooling = parser(Buffer.from('c1210141390000009d004641716d000000000000', 'hex'));
 assert.strictEqual(group41Cooling.compressorFrequency, 57);
-assert.strictEqual(group41Cooling.outdoorPipeTemperatureCandidate, 53.5);
+assert.strictEqual(group41Cooling.group41Byte08Raw, 157);
+assert.strictEqual(group41Cooling.group41Byte08TemperatureCandidate, 53.5);
 assert.strictEqual(group41Cooling.indoorPipeTemperature, 20);
 assert.strictEqual(group41Cooling.indoorHeatExchangerTemperature, 15);
-assert.strictEqual(group41Cooling.outdoorCoilTemperatureCandidate, 31.5);
+assert.strictEqual(group41Cooling.outdoorHeatExchangerTemperatureCandidate, 31.5);
 assert.strictEqual(group41Cooling.outdoorTemperatureGroup41, 29.5);
 
 const group41Heating = parser(Buffer.from('c12101411b0000009d005a66706b000000000000', 'hex'));
 assert.strictEqual(group41Heating.compressorFrequency, 27);
-assert.strictEqual(group41Heating.outdoorPipeTemperatureCandidate, 53.5);
+assert.strictEqual(group41Heating.group41Byte08Raw, 157);
+assert.strictEqual(group41Heating.group41Byte08TemperatureCandidate, 53.5);
 assert.strictEqual(group41Heating.indoorPipeTemperature, 40);
 assert.strictEqual(group41Heating.indoorHeatExchangerTemperature, 52);
-assert.strictEqual(group41Heating.outdoorCoilTemperatureCandidate, 31);
+assert.strictEqual(group41Heating.outdoorHeatExchangerTemperatureCandidate, 31);
 assert.strictEqual(group41Heating.outdoorTemperatureGroup41, 28.5);
 
 const shortGroup41 = parser(Buffer.from([0xc1, 0x21, 0x01, 0x41, 0x21]));

--- a/test/polling-config.test.js
+++ b/test/polling-config.test.js
@@ -108,26 +108,41 @@ assert.deepStrictEqual(
   { id: 'getPowerUsage', enabled: true, interval: 300 }
 );
 
-assert.deepStrictEqual(parseUnknownGroupIds('40,41,46').groups, [0x40, 0x41, 0x46]);
-assert.deepStrictEqual(parseUnknownGroupIds('0x40,0x41').groups, [0x40, 0x41]);
-assert.deepStrictEqual(parseUnknownGroupIds('29,30,40,50,60,zz,0x5f'), {
-  groups: [0x30, 0x40, 0x50, 0x5f],
-  invalid: ['29', '60', 'zz'],
+assert.deepStrictEqual(parseUnknownGroupIds('40,41,46'), {
+  groups: [0x40, 0x46],
+  invalid: [],
   duplicates: [],
+  skippedRegular: [0x41],
+  truncated: false,
+});
+assert.deepStrictEqual(parseUnknownGroupIds('0x40,0x41'), {
+  groups: [0x40],
+  invalid: [],
+  duplicates: [],
+  skippedRegular: [0x41],
+  truncated: false,
+});
+assert.deepStrictEqual(parseUnknownGroupIds('20,21,30,31,41,44,45,50,51,60,7F,80,xx'), {
+  groups: [0x20, 0x21, 0x30, 0x31, 0x50, 0x51, 0x60, 0x7f],
+  invalid: ['80', 'xx'],
+  duplicates: [],
+  skippedRegular: [0x41, 0x44, 0x45],
   truncated: false,
 });
 assert.deepStrictEqual(parseUnknownGroupIds('40,0x40,41,41'), {
-  groups: [0x40, 0x41],
+  groups: [0x40],
   invalid: [],
   duplicates: [0x40, 0x41],
+  skippedRegular: [0x41],
   truncated: false,
 });
-assert.deepStrictEqual(parseUnknownGroupIds('30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46'), {
+assert.deepStrictEqual(parseUnknownGroupIds('20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36'), {
   groups: [
-    0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x40, 0x41, 0x42, 0x43, 0x44, 0x45,
+    0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35,
   ],
   invalid: [],
   duplicates: [],
+  skippedRegular: [],
   truncated: true,
 });
 


### PR DESCRIPTION
### Motivation
- Erweiterung des experimentellen Unknown-Group-Diagnosemodus, um mehr Gruppen für Protokollanalyse zu erlauben und gleichzeitig nur sichere Leseanfragen zu senden.
- Group 41 soll weiter regulär pollbar bleiben, aber die Byte-Mapping- und Benennungskonventionen sollen den neuen Erkenntnissen folgen (Byte08 neutral, zusätzliche Temperatur-Kandidat-Ausgabe).
- Alte unklare Candidate-/Raw-Massenstates entfernen und nur kompakte Raw-Hex-Ausgabe behalten.
- Saubere Objekt-/State-Namen und vorsichtige Migration (nur eigene Namespace-States löschen) zur Vermeidung von Doppelungen/Verwirrung.

### Description
- Unknown-Group-Modus erweitert auf den Bereich `0x20–0x7F` mit Sicherheitsregeln: maximal 16 Gruppen, Mindestintervall 10s, sequentielle Abfrage, nur 20‑Byte C1 Query-Frames (`41 21 01 <group> 00 ... 00`), keine Control-/B0-/SetFrames, regulär unterstützte Gruppen (`0x41`,`0x44`,`0x45`) werden bei der Validierung übersprungen und mit Debug geloggt; Implementierung in `lib/polling-config.js` und `main.js`.
- Group 41 Parsing/Mapping überarbeitet: neu ausgegebene Felder sind `compressorFrequency`, `group41Byte08Raw`, `group41Byte08TemperatureCandidate`, `indoorPipeTemperature`, `indoorHeatExchangerTemperature`, `outdoorHeatExchangerTemperatureCandidate`, `outdoorTemperatureGroup41` mit Formeln/Skalierung wie vereinbart; Änderungen in `lib/node-mideahvac/lib/parsers/C1.js` und `main.js`.
- Neue/umbenannte Datapoints angelegt: `group41Byte08Raw`, `group41Byte08TemperatureCandidate`, `outdoorHeatExchangerTemperatureCandidate`, `compressorFrequency`, `indoorPipeTemperature`, `indoorHeatExchangerTemperature` usw.; Anpassungen in `lib/datapoints.js` und `io-package.json`/`admin/jsonConfig.json` (Admin‑Doku aktualisiert).
- Alte Group‑41‑Candidate-IDs werden beim Adapterstart im eigenen Namespace entfernt (nur die aufgelisteten legacy IDs), um keine alten Candidate‑States weiter zu pflegen; Implementierung in `main.js` (`_cleanupLegacyGroup41CandidateStates`).
- Raw-Hex-Handling: Unknown-Groups schreiben nur `statusRaw.unknownGroups.groupXX.rawFrameHex` und `statusRaw.unknownGroups.groupXX.payloadHex`; keine `rawByteXX`/`rawByteXXBits`/`analogCandidates` wieder eingeführt; Group41 behält kompakte `statusRaw.group41_*` Ausgaben; Änderungen in `main.js`.
- Versions- und Changelog-Update auf `0.0.9` sowie README/CHANGELOG/io-package-News ergänzt.

### Testing
- Lokale Test-Suite ausgeführt mit `npm test` (entspricht `test:raw-parser-helper`, `test:c1-parser`, `test:polling-config` und `eslint`).
- Alle automatisierten Tests bestanden und `eslint` lief erfolgreich nach Formatierung (`npm test` => ✅ all tests passed).
- Enthaltene Parser-Tests prüfen die beiden Beispiel-Payloads für Group 41 sowie das erweiterte Unknown-Group-Parsing (inkl. Eingabe `20,21,30,31,41,44,45,50,51,60,7F,80,xx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2720f2919c8325aa4e2582836cd92e)