### PR TITLE
Add C1 Group 43 diagnostic polling and outdoorFanCommandCandidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 ## **WORK IN PROGRESS**
 
+## 0.0.11 (2026-06-09)
+
+- add regular `getGroup43Data` polling for C1 Group 43 diagnostics
+- expose C1 Group 43 byte 10 as `outdoorFanCommandCandidate` without rpm semantics
+- add compact Group 43 raw hex states and skip Group 43 in unknown-group polling
+
 ## 0.0.10 (2026-06-09)
 
 - remove the legacy custom-polling switch from the Admin UI and ignore legacy customPolling fields during normalization
 - normalize pollingRequests as the authoritative polling table, including migration from legacy polling.requests, duplicate cleanup, interval validation and missing default entries
 - align German and English polling request labels with C0, B5 and C1 Group naming
-
 
 ## 0.0.9 (2026-06-08)
 

--- a/README.md
+++ b/README.md
@@ -29,19 +29,20 @@ Open the adapter configuration in the ioBroker Admin. Enter the IP address (or h
 
 The cyclic request table contains these regular polling requests:
 
-| Request | Protocol response | Default |
-| ------- | ----------------- | ------- |
-| Status request / Statusabfrage | C0 | enabled, 60 s |
-| Capabilities / Fähigkeiten | B5 | disabled, 3600 s |
-| Energy counter / Energiezähler | C1 Group 44 | disabled, 300 s |
-| Group 5 data / Group-5-Daten | C1 Group 45 | disabled, 300 s |
-| Group 41 diagnostic data / Group-41-Diagnosedaten | C1 Group 41 | disabled, 60 s |
+| Request                                           | Protocol response | Default          |
+| ------------------------------------------------- | ----------------- | ---------------- |
+| Status request / Statusabfrage                    | C0                | enabled, 60 s    |
+| Capabilities / Fähigkeiten                        | B5                | disabled, 3600 s |
+| Energy counter / Energiezähler                    | C1 Group 44       | disabled, 300 s  |
+| Group 5 data / Group-5-Daten                      | C1 Group 45       | disabled, 300 s  |
+| Group 41 diagnostic data / Group-41-Diagnosedaten | C1 Group 41       | disabled, 60 s   |
+| Group 43 diagnostic data / Group-43-Diagnosedaten | C1 Group 43       | disabled, 60 s   |
 
 ### Unknown C1 group diagnosis mode
 
 For protocol analysis you can enable **Enable unknown group diagnosis polling** on the **Options** tab. This mode is intentionally read-only: it sends only safe 20-byte C1 query frames in the known `41 21 01 <group> 00 ... 00` schema and does not send control, SetStatus or B0 property-set frames.
 
-Configure **Unknown group IDs** as comma-separated hexadecimal group bytes from `0x20` to `0x7F`, for example `20,21,30,31,50,51,60,7F`. The adapter ignores invalid values and duplicates, enforces a minimum interval of 10 seconds, limits the list to 16 groups, and polls the groups sequentially with a small pause so the device is not flooded. Regularly supported groups (`0x41` / `getGroup41Data`, `0x44` / power usage, `0x45` / Group 5 data) are skipped in this mode with a debug note.
+Configure **Unknown group IDs** as comma-separated hexadecimal group bytes from `0x20` to `0x7F`, for example `20,21,30,31,50,51,60,7F`. The adapter ignores invalid values and duplicates, enforces a minimum interval of 10 seconds, limits the list to 16 groups, and polls the groups sequentially with a small pause so the device is not flooded. Regularly supported groups (`0x41` / `getGroup41Data`, `0x43` / `getGroup43Data`, `0x44` / power usage, `0x45` / Group 5 data) are skipped in this mode with a debug note.
 
 Responses are written only below `statusRaw.unknownGroups.groupXX.*` for analysis and never create normal sensor datapoints. Each response includes only compact raw hex states: `rawFrameHex` and `payloadHex`. The mode intentionally does not create `rawByteXX`, `rawByteXXBits` or `analogCandidates` mass states. Compare `payloadHex` while changing real-world conditions to identify frame-level differences.
 
@@ -50,6 +51,10 @@ Responses are written only below `statusRaw.unknownGroups.groupXX.*` for analysi
 The regular polling configuration includes `getGroup41Data`, a read-only 20-byte C1 query (`41 21 01 41 00 ... 00`) for Group 41 diagnostic data. The decoded values are exposed as normal `sensors.*` datapoints. Some Group 41 values are still experimental and can differ between Midea devices, so uncertain values keep `Candidate` / `Kandidat` in their state IDs, names and descriptions.
 
 Group 41 currently exposes the confirmed compressor frequency, indoor pipe temperature, indoor heat exchanger temperature and Group 41 outdoor temperature. Byte 08 remains unclear and is therefore exposed neutrally as a raw value plus one temperature candidate. Byte 12 remains a candidate for an outdoor-unit / condenser / heat-exchanger temperature. Byte 10 and byte 11 use the `raw - 50` scaling found in newer logs; byte 08, byte 12 and byte 13 use `(byte - 50) / 2` for the temperature values. When raw status output is enabled, compact Group 41 raw values remain available as `statusRaw.group41_rawFrameHex` and `statusRaw.group41_payloadHex`.
+
+### C1 Group 43 diagnostic data
+
+The regular polling configuration includes `getGroup43Data`, a read-only 20-byte C1 query (`41 21 01 43 00 ... 00`) for Group 43 diagnostic data. Byte 10 is exposed as `sensors.outdoorFanCommandCandidate`, a candidate for outdoor fan command or outdoor fan demand. Observed values include `0` in fan/off and `87`/`97` in cooling/heating; the value is intentionally not named or treated as a confirmed rpm speed. When raw status output is enabled, compact Group 43 raw values are available as `statusRaw.group43_rawFrameHex` and `statusRaw.group43_payloadHex`.
 
 The following datapoints are available out of the box:
 
@@ -68,6 +73,7 @@ The following datapoints are available out of the box:
 | `indoorHeatExchangerTemperature`           | Indoor heat exchanger / pipe temperature from C1 Group 41 byte 11 (°C)                        | ✓    | ✗     |
 | `outdoorHeatExchangerTemperatureCandidate` | Candidate outdoor-unit, condenser or heat exchanger temperature from C1 Group 41 byte 12 (°C) | ✓    | ✗     |
 | `outdoorTemperatureGroup41`                | Outdoor temperature from C1 Group 41 byte 13 (°C)                                             | ✓    | ✗     |
+| `outdoorFanCommandCandidate`               | Candidate outdoor fan command / demand from C1 Group 43 byte 10; not confirmed as rpm         | ✓    | ✗     |
 | `fanSpeed`                                 | Fan speed (auto, low, medium, high)                                                           | ✓    | ✓     |
 | `swingMode`                                | Swing mode (off, vertical, horizontal, both)                                                  | ✓    | ✓     |
 | `ecoMode`                                  | Eco mode                                                                                      | ✓    | ✓     |

--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -32,5 +32,6 @@
   "getCapabilities": "Fähigkeiten (B5)",
   "getPowerUsage": "Energiezähler (C1 Group 44)",
   "getGroup5Data": "Group-5-Daten (C1 Group 45)",
-  "getGroup41Data": "Group-41-Diagnosedaten (C1 Group 41)"
+  "getGroup41Data": "Group-41-Diagnosedaten (C1 Group 41)",
+  "getGroup43Data": "Group-43-Diagnosedaten (C1 Group 43)"
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -32,5 +32,6 @@
   "getCapabilities": "Capabilities (B5)",
   "getPowerUsage": "Energy counter (C1 Group 44)",
   "getGroup5Data": "Group 5 data (C1 Group 45)",
-  "getGroup41Data": "Group 41 diagnostic data (C1 Group 41)"
+  "getGroup41Data": "Group 41 diagnostic data (C1 Group 41)",
+  "getGroup43Data": "Group 43 diagnostic data (C1 Group 43)"
 }

--- a/admin/i18n/es/translations.json
+++ b/admin/i18n/es/translations.json
@@ -32,5 +32,6 @@
   "getPowerUsage": "Energy counter (C1 Group 44)",
   "options": "Options",
   "getGroup5Data": "Group 5 data (C1 Group 45)",
-  "getGroup41Data": "Group 41 diagnostic data (C1 Group 41)"
+  "getGroup41Data": "Group 41 diagnostic data (C1 Group 41)",
+  "getGroup43Data": "Group 43 diagnostic data (C1 Group 43)"
 }

--- a/admin/i18n/fr/translations.json
+++ b/admin/i18n/fr/translations.json
@@ -32,5 +32,6 @@
   "getPowerUsage": "Energy counter (C1 Group 44)",
   "options": "Options",
   "getGroup5Data": "Group 5 data (C1 Group 45)",
-  "getGroup41Data": "Group 41 diagnostic data (C1 Group 41)"
+  "getGroup41Data": "Group 41 diagnostic data (C1 Group 41)",
+  "getGroup43Data": "Group 43 diagnostic data (C1 Group 43)"
 }

--- a/admin/i18n/it/translations.json
+++ b/admin/i18n/it/translations.json
@@ -32,5 +32,6 @@
   "getPowerUsage": "Energy counter (C1 Group 44)",
   "options": "Options",
   "getGroup5Data": "Group 5 data (C1 Group 45)",
-  "getGroup41Data": "Group 41 diagnostic data (C1 Group 41)"
+  "getGroup41Data": "Group 41 diagnostic data (C1 Group 41)",
+  "getGroup43Data": "Group 43 diagnostic data (C1 Group 43)"
 }

--- a/admin/i18n/nl/translations.json
+++ b/admin/i18n/nl/translations.json
@@ -32,5 +32,6 @@
   "getPowerUsage": "Energy counter (C1 Group 44)",
   "options": "Options",
   "getGroup5Data": "Group 5 data (C1 Group 45)",
-  "getGroup41Data": "Group 41 diagnostic data (C1 Group 41)"
+  "getGroup41Data": "Group 41 diagnostic data (C1 Group 41)",
+  "getGroup43Data": "Group 43 diagnostic data (C1 Group 43)"
 }

--- a/admin/i18n/pl/translations.json
+++ b/admin/i18n/pl/translations.json
@@ -32,5 +32,6 @@
   "getPowerUsage": "Energy counter (C1 Group 44)",
   "options": "Options",
   "getGroup5Data": "Group 5 data (C1 Group 45)",
-  "getGroup41Data": "Group 41 diagnostic data (C1 Group 41)"
+  "getGroup41Data": "Group 41 diagnostic data (C1 Group 41)",
+  "getGroup43Data": "Group 43 diagnostic data (C1 Group 43)"
 }

--- a/admin/i18n/pt/translations.json
+++ b/admin/i18n/pt/translations.json
@@ -32,5 +32,6 @@
   "getPowerUsage": "Energy counter (C1 Group 44)",
   "options": "Options",
   "getGroup5Data": "Group 5 data (C1 Group 45)",
-  "getGroup41Data": "Group 41 diagnostic data (C1 Group 41)"
+  "getGroup41Data": "Group 41 diagnostic data (C1 Group 41)",
+  "getGroup43Data": "Group 43 diagnostic data (C1 Group 43)"
 }

--- a/admin/i18n/ru/translations.json
+++ b/admin/i18n/ru/translations.json
@@ -32,5 +32,6 @@
   "getPowerUsage": "Energy counter (C1 Group 44)",
   "options": "Options",
   "getGroup5Data": "Group 5 data (C1 Group 45)",
-  "getGroup41Data": "Group 41 diagnostic data (C1 Group 41)"
+  "getGroup41Data": "Group 41 diagnostic data (C1 Group 41)",
+  "getGroup43Data": "Group 43 diagnostic data (C1 Group 43)"
 }

--- a/admin/i18n/uk/translations.json
+++ b/admin/i18n/uk/translations.json
@@ -32,5 +32,6 @@
   "getPowerUsage": "Energy counter (C1 Group 44)",
   "options": "Options",
   "getGroup5Data": "Group 5 data (C1 Group 45)",
-  "getGroup41Data": "Group 41 diagnostic data (C1 Group 41)"
+  "getGroup41Data": "Group 41 diagnostic data (C1 Group 41)",
+  "getGroup43Data": "Group 43 diagnostic data (C1 Group 43)"
 }

--- a/admin/i18n/zh-cn/translations.json
+++ b/admin/i18n/zh-cn/translations.json
@@ -32,5 +32,6 @@
   "getPowerUsage": "Energy counter (C1 Group 44)",
   "options": "Options",
   "getGroup5Data": "Group 5 data (C1 Group 45)",
-  "getGroup41Data": "Group 41 diagnostic data (C1 Group 41)"
+  "getGroup41Data": "Group 41 diagnostic data (C1 Group 41)",
+  "getGroup43Data": "Group 43 diagnostic data (C1 Group 43)"
 }

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -338,6 +338,13 @@
                     "en": "Group 41 diagnostic data (C1 Group 41)",
                     "de": "Group-41-Diagnosedaten (C1 Group 41)"
                   }
+                },
+                {
+                  "value": "getGroup43Data",
+                  "label": {
+                    "en": "Group 43 diagnostic data (C1 Group 43)",
+                    "de": "Group-43-Diagnosedaten (C1 Group 43)"
+                  }
                 }
               ]
             },
@@ -377,6 +384,11 @@
             },
             {
               "id": "getGroup41Data",
+              "enabled": false,
+              "interval": 60
+            },
+            {
+              "id": "getGroup43Data",
               "enabled": false,
               "interval": 60
             }

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "name": "midea-serialbridge",
-    "version": "0.0.10",
+    "version": "0.0.11",
     "titleLang": {
       "en": "Midea Serial Bridge",
       "de": "Midea Serial Bridge",
@@ -42,26 +42,23 @@
       "config": "json"
     },
     "readme": "https://github.com/dosordie/ioBroker.midea-serialbridge/blob/main/README.md",
-    "keywords": [
-      "midea",
-      "hvac",
-      "serial",
-      "climate"
-    ],
+    "keywords": ["midea", "hvac", "serial", "climate"],
     "dependencies": [
       {
         "js-controller": ">=5.0.19"
       }
     ],
-    "authors": [
-      "dosordie <info@dosordie.de>"
-    ],
+    "authors": ["dosordie <info@dosordie.de>"],
     "licenseInformation": {
       "license": "MIT",
       "url": "https://github.com/dosordie/ioBroker.midea-serialbridge/blob/main/LICENSE",
       "type": "open-source"
     },
     "news": {
+      "0.0.11": {
+        "en": "Add regular C1 Group 43 diagnostic polling and expose the outdoor fan command candidate value.",
+        "de": "Ergänzt reguläres C1-Group-43-Diagnose-Polling und gibt den Außenlüfter-Ansteuerungs-Kandidaten aus."
+      },
       "0.0.10": {
         "en": "Clean up polling configuration, remove the legacy custom-polling switch from the admin UI, and normalize polling request defaults.",
         "de": "Bereinigt die Polling-Konfiguration, entfernt den Legacy-Schalter für individuelles Polling aus der Admin-Oberfläche und normalisiert die Polling-Defaults."
@@ -153,6 +150,11 @@
       },
       {
         "id": "getGroup41Data",
+        "enabled": false,
+        "interval": 60
+      },
+      {
+        "id": "getGroup43Data",
         "enabled": false,
         "interval": 60
       }

--- a/lib/datapoints.js
+++ b/lib/datapoints.js
@@ -223,6 +223,21 @@ const DATA_POINTS = [
     readOnly: true,
   },
   {
+    id: 'outdoorFanCommandCandidate',
+    channel: 'sensors',
+    name: {
+      en: 'Outdoor fan command candidate',
+      de: 'Außenlüfter-Ansteuerung Kandidat',
+    },
+    desc: {
+      en: 'Candidate: outdoor fan command or outdoor fan demand from C1 Group 43 byte 10. Observed values: 0 in fan/off, 87/97 in cooling/heating. Not confirmed as rpm.',
+      de: 'Kandidat: Außenlüfter-Ansteuerung oder Außenlüfter-Sollwert aus C1 Group 43 Byte 10. Werte aus Logs: 0 bei Lüften/Aus, 87/97 bei Kühlen/Heizen. Keine bestätigte Drehzahl in rpm.',
+    },
+    role: 'value',
+    type: 'number',
+    readOnly: true,
+  },
+  {
     id: 'compressorFrequency',
     channel: 'sensors',
     name: {

--- a/lib/midea-serial-bridge.js
+++ b/lib/midea-serial-bridge.js
@@ -182,6 +182,19 @@ class MideaSerialBridge extends EventEmitter {
     return group41Data;
   }
 
+  async getGroup43Data() {
+    if (!this.device) {
+      throw new Error('Bridge not connected');
+    }
+
+    const group43Data = await this.device.getGroup43Data();
+    if (group43Data && typeof group43Data === 'object') {
+      const mapped = this._handleStatus(group43Data);
+      this.emit('group43Data', { ...group43Data, ...mapped });
+    }
+    return group43Data;
+  }
+
   async set(datapointId, value) {
     if (!this.device) {
       throw new Error('Bridge not connected');

--- a/lib/node-mideahvac/lib/ac.js
+++ b/lib/node-mideahvac/lib/ac.js
@@ -299,6 +299,36 @@ module.exports = class extends EventEmitter {
     });
   }
 
+  getGroup43Data(retry = 0) {
+    const self = this;
+
+    logger.silly('AC.getGroup43Data: Entering');
+
+    const cmd = createGroupDataCommandByByte(0x43);
+
+    return new Promise((resolve, reject) => {
+      self
+        ._request(cmd, 'getGroup43Data', retry)
+        .then((response) => {
+          if (response[10] !== 0xc1) {
+            return reject(new Error('Invalid response'));
+          }
+
+          const parsedData = self._parseResponse(response);
+          const updates = self._updateStatus(parsedData);
+
+          if (Object.keys(updates).length) {
+            self.emit('status-update', reporter(updates));
+          }
+
+          resolve(reporter(parsedData));
+        })
+        .catch((error) => {
+          reject(error);
+        });
+    });
+  }
+
   getStatus(retry = 0) {
     const self = this;
 

--- a/lib/node-mideahvac/lib/parsers/C1.js
+++ b/lib/node-mideahvac/lib/parsers/C1.js
@@ -88,6 +88,25 @@ function decodeGroup41IndoorTemperature(value) {
   return value - 50;
 }
 
+function parseGroup43(data) {
+  if (data.length <= 10) {
+    logger.debug(
+      `C1.parser: Group 43 payload too short (${data.length}); expected at least 11 bytes`
+    );
+    return {};
+  }
+
+  const status = {
+    outdoorFanCommandCandidate: data[10],
+  };
+
+  logger.debug(
+    `C1.parser: Decoded group 43 diagnostic data: outdoorFanCommandCandidate=${status.outdoorFanCommandCandidate}`
+  );
+
+  return status;
+}
+
 function parseGroup41(data) {
   if (data.length < 14) {
     logger.debug(
@@ -129,6 +148,9 @@ exports.parser = (data, options = {}) => {
     case 0x41:
       status = parseGroup41(data);
       break;
+    case 0x43:
+      status = parseGroup43(data);
+      break;
     case 0x44:
       status = parsePowerUsage(data);
       break;
@@ -146,6 +168,11 @@ exports.parser = (data, options = {}) => {
   if (groupByte === 0x41) {
     status.group41_rawFrameHex = options.frame ? options.frame.toString('hex') : '';
     status.group41_payloadHex = data.toString('hex');
+  }
+
+  if (groupByte === 0x43) {
+    status.group43_rawFrameHex = options.frame ? options.frame.toString('hex') : '';
+    status.group43_payloadHex = data.toString('hex');
   }
 
   return addRawHexDebug(status, data, options);

--- a/lib/polling-config.js
+++ b/lib/polling-config.js
@@ -46,6 +46,15 @@ const POLLING_METHODS = [
       de: 'Group-41-Diagnosedaten (C1 Group 41)',
     },
   },
+  {
+    id: 'getGroup43Data',
+    defaultEnabled: false,
+    defaultInterval: 60,
+    label: {
+      en: 'Group 43 diagnostic data (C1 Group 43)',
+      de: 'Group-43-Diagnosedaten (C1 Group 43)',
+    },
+  },
 ];
 
 const POLLING_METHOD_MAP = new Map(POLLING_METHODS.map((entry) => [entry.id, entry]));
@@ -56,6 +65,7 @@ const UNKNOWN_GROUP_MAX_COUNT = 16;
 const UNKNOWN_GROUP_MIN_INTERVAL = 10;
 const REGULAR_GROUP_BYTES = new Map([
   [0x41, 'getGroup41Data'],
+  [0x43, 'getGroup43Data'],
   [0x44, 'getPowerUsage'],
   [0x45, 'getGroup5Data'],
 ]);

--- a/main.js
+++ b/main.js
@@ -197,6 +197,12 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
         });
       });
 
+      this.bridge.on('group43Data', (group43Data) => {
+        this._applyGroup43Data(group43Data).catch((error) => {
+          this.log.debug(`Failed to process group 43 update: ${this._formatError(error)}`);
+        });
+      });
+
       this.bridge.on('unknownGroupData', (groupData) => {
         this._applyUnknownGroupData(groupData).catch((error) => {
           this.log.debug(`Failed to process unknown group update: ${this._formatError(error)}`);
@@ -607,9 +613,9 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
     if (result.skippedRegular && result.skippedRegular.length > 0) {
       for (const group of result.skippedRegular) {
         this.log.debug(
-          `Skipping unknown group 0x${formatUnknownGroupId(
+          `Group 0x${formatUnknownGroupId(
             group
-          )} because it is supported as regular group`
+          )} is supported as regular polling method and skipped in unknown group polling`
         );
       }
     }
@@ -723,6 +729,9 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
         break;
       case 'getGroup41Data':
         this._pollGroup41Data();
+        break;
+      case 'getGroup43Data':
+        this._pollGroup43Data();
         break;
       default:
         this.log.debug(`No polling handler registered for ${methodId}`);
@@ -1144,6 +1153,20 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
     }
   }
 
+  async _pollGroup43Data() {
+    if (!this.bridge || !this.bridge.connected) {
+      return;
+    }
+
+    this.log.debug('Polling group 43 data now');
+
+    try {
+      await this.bridge.getGroup43Data();
+    } catch (error) {
+      this.log.warn(`Polling group 43 diagnostic data failed: ${error.message}`);
+    }
+  }
+
   async _pollUnknownGroupsSequentially(groups) {
     if (!this.bridge || !this.bridge.connected || !Array.isArray(groups) || groups.length === 0) {
       return;
@@ -1488,6 +1511,50 @@ class MideaSerialBridgeAdapter extends utils.Adapter {
       } catch (error) {
         this.log.debug(
           `Failed to update group 41 state ${datapointId}: ${this._formatError(error)}`
+        );
+      }
+    }
+  }
+
+  async _applyGroup43Data(group43Data) {
+    if (!group43Data || typeof group43Data !== 'object') {
+      return;
+    }
+
+    this.log.debug(
+      `Received group 43 payload: ${group43Data.group43_payloadHex || group43Data.payloadHex || ''}`
+    );
+    this.log.debug(
+      `Decoded group 43 diagnostic data: outdoorFanCommandCandidate=${group43Data.outdoorFanCommandCandidate}`
+    );
+
+    if (this.config && this.config.exposeRawStatus) {
+      const rawEntries = Object.entries({
+        group43_rawFrameHex: group43Data.group43_rawFrameHex || group43Data.rawFrameHex || '',
+        group43_payloadHex: group43Data.group43_payloadHex || group43Data.payloadHex || '',
+      });
+      await this._applyRawStatus(rawEntries);
+    }
+
+    const mapped = {
+      outdoorFanCommandCandidate: group43Data.outdoorFanCommandCandidate,
+    };
+
+    for (const [datapointId, value] of Object.entries(mapped)) {
+      if (!this.datapointById.has(datapointId) || value === undefined) {
+        continue;
+      }
+
+      const datapoint = this.datapointById.get(datapointId);
+      const normalized = this._normalizeReadValue(datapoint, value);
+      try {
+        await this.setStateAsync(`${datapoint.channel}.${datapoint.id}`, {
+          val: normalized,
+          ack: true,
+        });
+      } catch (error) {
+        this.log.debug(
+          `Failed to update group 43 state ${datapointId}: ${this._formatError(error)}`
         );
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iobroker.midea-serialbridge",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iobroker.midea-serialbridge",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "MIT",
       "dependencies": {
         "@iobroker/adapter-core": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.midea-serialbridge",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "ioBroker adapter for controlling Midea climate devices via serial bridge",
   "author": {
     "name": "dosordie"

--- a/test/c1-parser.test.js
+++ b/test/c1-parser.test.js
@@ -90,6 +90,22 @@ assert.strictEqual(group41Heating.indoorHeatExchangerTemperature, 52);
 assert.strictEqual(group41Heating.outdoorHeatExchangerTemperatureCandidate, 31);
 assert.strictEqual(group41Heating.outdoorTemperatureGroup41, 28.5);
 
+for (const value of [87, 97, 0]) {
+  const group43 = Buffer.from('c121014300000000000000000000000000000000', 'hex');
+  group43[10] = value;
+  const parsedGroup43 = parser(group43, { frame: Buffer.from([0xaa, 0x43]) });
+  assert.strictEqual(parsedGroup43.outdoorFanCommandCandidate, value);
+  assert.strictEqual(parsedGroup43.group, 3);
+  assert.strictEqual(parsedGroup43.group43_rawFrameHex, 'aa43');
+  assert.strictEqual(parsedGroup43.group43_payloadHex, group43.toString('hex'));
+  assert.strictEqual(parsedGroup43.rawFrameHex, 'aa43');
+  assert.strictEqual(parsedGroup43.payloadHex, group43.toString('hex'));
+  assert.strictEqual(parsedGroup43.rawBytes, undefined);
+  assert.strictEqual(parsedGroup43.rawByte10, undefined);
+  assert.strictEqual(parsedGroup43.rawByte10Bits, undefined);
+  assert.strictEqual(parsedGroup43.analogCandidates, undefined);
+}
+
 const shortGroup41 = parser(Buffer.from([0xc1, 0x21, 0x01, 0x41, 0x21]));
 assert.strictEqual(shortGroup41.compressorFrequency, undefined);
 assert.strictEqual(shortGroup41.group, 1);

--- a/test/polling-config.test.js
+++ b/test/polling-config.test.js
@@ -1,7 +1,11 @@
 'use strict';
 
 const assert = require('assert');
-const { normalizePollingRequests, parseUnknownGroupIds } = require('../lib/polling-config');
+const {
+  POLLING_METHOD_MAP,
+  normalizePollingRequests,
+  parseUnknownGroupIds,
+} = require('../lib/polling-config');
 
 const DEFAULT_REQUESTS = [
   { id: 'getStatus', enabled: true, interval: 60 },
@@ -9,6 +13,7 @@ const DEFAULT_REQUESTS = [
   { id: 'getPowerUsage', enabled: false, interval: 300 },
   { id: 'getGroup5Data', enabled: false, interval: 300 },
   { id: 'getGroup41Data', enabled: false, interval: 60 },
+  { id: 'getGroup43Data', enabled: false, interval: 60 },
 ];
 
 assert.deepStrictEqual(normalizePollingRequests({}), DEFAULT_REQUESTS);
@@ -46,6 +51,7 @@ assert.deepStrictEqual(
     { id: 'getPowerUsage', enabled: true, interval: 45 },
     { id: 'getGroup5Data', enabled: false, interval: 300 },
     { id: 'getGroup41Data', enabled: false, interval: 60 },
+    { id: 'getGroup43Data', enabled: false, interval: 60 },
   ]
 );
 
@@ -62,6 +68,7 @@ assert.deepStrictEqual(
     { id: 'getPowerUsage', enabled: false, interval: 300 },
     { id: 'getGroup5Data', enabled: false, interval: 300 },
     { id: 'getGroup41Data', enabled: false, interval: 60 },
+    { id: 'getGroup43Data', enabled: false, interval: 60 },
   ]
 );
 
@@ -88,6 +95,7 @@ assert.deepStrictEqual(
     { id: 'getPowerUsage', enabled: false, interval: 300 },
     { id: 'getGroup5Data', enabled: true, interval: 60 },
     { id: 'getGroup41Data', enabled: false, interval: 60 },
+    { id: 'getGroup43Data', enabled: false, interval: 60 },
   ]
 );
 
@@ -95,7 +103,14 @@ assert.deepStrictEqual(
   normalizePollingRequests({
     pollingRequests: [{ id: 'getStatus', enabled: true, interval: 60 }],
   }).map((entry) => entry.id),
-  ['getStatus', 'getCapabilities', 'getPowerUsage', 'getGroup5Data', 'getGroup41Data']
+  [
+    'getStatus',
+    'getCapabilities',
+    'getPowerUsage',
+    'getGroup5Data',
+    'getGroup41Data',
+    'getGroup43Data',
+  ]
 );
 
 assert.deepStrictEqual(
@@ -121,16 +136,25 @@ assert.deepStrictEqual(
 
 assert.deepStrictEqual(
   normalizePollingRequests({
+    pollingRequests: [{ id: 'getGroup43Data', enabled: true, interval: 60 }],
+  }).find((entry) => entry.id === 'getGroup43Data'),
+  { id: 'getGroup43Data', enabled: true, interval: 60 }
+);
+
+assert.strictEqual(POLLING_METHOD_MAP.has('getGroup43Data'), true);
+
+assert.deepStrictEqual(
+  normalizePollingRequests({
     pollingRequests: [{ id: 'getPowerUsage', enabled: 'true', interval: 'not-a-number' }],
   }).find((entry) => entry.id === 'getPowerUsage'),
   { id: 'getPowerUsage', enabled: true, interval: 300 }
 );
 
-assert.deepStrictEqual(parseUnknownGroupIds('40,41,46'), {
+assert.deepStrictEqual(parseUnknownGroupIds('40,41,43,46'), {
   groups: [0x40, 0x46],
   invalid: [],
   duplicates: [],
-  skippedRegular: [0x41],
+  skippedRegular: [0x41, 0x43],
   truncated: false,
 });
 assert.deepStrictEqual(parseUnknownGroupIds('0x40,0x41'), {
@@ -140,11 +164,11 @@ assert.deepStrictEqual(parseUnknownGroupIds('0x40,0x41'), {
   skippedRegular: [0x41],
   truncated: false,
 });
-assert.deepStrictEqual(parseUnknownGroupIds('20,21,30,31,41,44,45,50,51,60,7F,80,xx'), {
+assert.deepStrictEqual(parseUnknownGroupIds('20,21,30,31,41,43,44,45,50,51,60,7F,80,xx'), {
   groups: [0x20, 0x21, 0x30, 0x31, 0x50, 0x51, 0x60, 0x7f],
   invalid: ['80', 'xx'],
   duplicates: [],
-  skippedRegular: [0x41, 0x44, 0x45],
+  skippedRegular: [0x41, 0x43, 0x44, 0x45],
   truncated: false,
 });
 assert.deepStrictEqual(parseUnknownGroupIds('40,0x40,41,41'), {


### PR DESCRIPTION
### Motivation
- Provide regular, opt-in polling for C1 Group 43 because logs show a consistent candidate value in byte 10 likely related to outdoor fan command/demand, without claiming rpm semantics.  
- Make Group 43 query available in the Admin polling table and skip it in unknown-group diagnosis to avoid duplicate requests.

### Description
- Add new polling method `getGroup43Data` to `POLLING_METHODS` and register `0x43` as a regularly supported group byte in `lib/polling-config.js`.  
- Implement `getGroup43Data` in the vendored AC helper (`lib/node-mideahvac/lib/ac.js`) and expose it through the bridge (`lib/midea-serial-bridge.js`).  
- Extend the C1 parser (`lib/node-mideahvac/lib/parsers/C1.js`) to decode C1 Group 43 and map `payload[10]` to `outdoorFanCommandCandidate`, and add compact raw hex fields `group43_rawFrameHex` / `group43_payloadHex`.  
- Add a new datapoint `sensors.outdoorFanCommandCandidate` in `lib/datapoints.js` with German/English names and neutral candidate description (no `rpm` unit).  
- Wire adapter handling: subscribe to `group43Data` events, implement `_pollGroup43Data()` and `_applyGroup43Data()` in `main.js`, emit debug logs when polling/receiving/decoding Group 43, and write compact raw hex under `statusRaw.*` when `exposeRawStatus` is enabled.  
- Update Admin `pollingRequests` UI (`admin/jsonConfig.json`) and i18n entries to include `getGroup43Data`, update `README.md` and `CHANGELOG.md`, and bump package version to `0.0.11`.  
- Ensure Unknown-Group diagnosis skips `0x43` and logs: `Group 0x43 is supported as regular polling method and skipped in unknown group polling`.

### Testing
- Ran unit tests with `npm test`, which executed `test/raw-parser-helper.test.js`, `test/c1-parser.test.js` and `test/polling-config.test.js`, and all tests passed.  
- Lint (`eslint .`) ran as part of `npm test` and completed with no reported errors.
- Included parser tests that assert `outdoorFanCommandCandidate` equals `87`, `97`, and `0` and that compact raw hex fields exist and no `rawByte*`/`analogCandidates` mass states are created (`test/c1-parser.test.js`).  
- Added polling-config tests to verify `getGroup43Data` appears in normalized polling defaults, is handled by the normalizer and is skipped by unknown-group parsing (`test/polling-config.test.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a281e1d3818832595a5e384509ad1a6)